### PR TITLE
Remove GuiceOneAppPerSuite from SpecBase

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,15 @@ lazy val appName: String = "declare-transit-movement-departure-frontend"
 
 resolvers += "hmrc-releases" at "https://artefacts.tax.service.gov.uk/artifactory/hmrc-releases/"
 
+val silencerVersion = "1.7.0"
+
 lazy val root = (project in file("."))
-  .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtDistributablesPlugin, SbtArtifactory)
+  .enablePlugins(
+    PlayScala,
+    SbtAutoBuildPlugin,
+    SbtDistributablesPlugin,
+    SbtArtifactory
+  )
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(DefaultBuildSettings.scalaSettings: _*)
   .settings(DefaultBuildSettings.defaultSettings(): _*)
@@ -35,7 +42,7 @@ lazy val root = (project in file("."))
     ScoverageKeys.coverageMinimum := 80,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true,
-    useSuperShell in ThisBuild     := false,
+    useSuperShell in ThisBuild := false,
     scalacOptions ++= Seq("-feature"),
     libraryDependencies ++= AppDependencies(),
     dependencyOverrides += "commons-codec" % "commons-codec" % "1.12", //added for reactive mongo issues
@@ -47,17 +54,29 @@ lazy val root = (project in file("."))
       Resolver.jcenterRepo
     ),
     Concat.groups := Seq(
-      "javascripts/application.js" -> group(Seq("lib/govuk-frontend/govuk/all.js", "javascripts/ctc.js"))
+      "javascripts/application.js" -> group(
+        Seq("lib/govuk-frontend/govuk/all.js", "javascripts/ctc.js")
+      )
     ),
     uglifyCompressOptions := Seq("unused=false", "dead_code=false"),
-    pipelineStages in Assets := Seq(concat,uglify)
+    pipelineStages in Assets := Seq(concat, uglify)
+  )
+  .settings(
+    // ***************
+    // Use the silencer plugin to suppress warnings
+    scalacOptions += "-P:silencer:pathFilters=routes",
+    libraryDependencies ++= Seq(
+      compilerPlugin(
+        "com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full
+      ),
+      "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full
+    )
+    // ***************
   )
 
 lazy val testSettings: Seq[Def.Setting[_]] = Seq(
-  fork        := true,
-  javaOptions ++= Seq(
-    "-Dconfig.resource=test.application.conf"
-  )
+  fork := true,
+  javaOptions ++= Seq("-Dconfig.resource=test.application.conf")
 )
 
 dependencyOverrides ++= AppDependencies.overrides

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -16,55 +16,59 @@
 
 package base
 
-import config.FrontendAppConfig
 import controllers.actions._
-import models.{EoriNumber, LocalReferenceNumber, UserAnswers}
+import models.EoriNumber
+import models.LocalReferenceNumber
+import models.UserAnswers
 import org.mockito.Mockito
-import org.scalatest.{BeforeAndAfterEach, OptionValues, TryValues}
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.OptionValues
+import org.scalatest.TryValues
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatestplus.play.guice._
-import play.api.i18n.{Messages, MessagesApi}
+import play.api.i18n.Messages
+import play.api.i18n.MessagesApi
+import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.inject.{Injector, bind}
 import play.api.libs.json.Json
-import play.api.mvc.AnyContentAsEmpty
-import play.api.test.FakeRequest
+import play.api.test.Helpers
 import uk.gov.hmrc.nunjucks.NunjucksRenderer
 
-trait SpecBase extends AnyFreeSpec with Matchers with GuiceOneAppPerSuite with OptionValues with TryValues
-  with ScalaFutures with IntegrationPatience with MockitoSugar with BeforeAndAfterEach {
+trait SpecBase
+    extends AnyFreeSpec
+    with Matchers
+    with OptionValues
+    with TryValues
+    with ScalaFutures
+    with IntegrationPatience
+    with MockitoSugar
+    with BeforeAndAfterEach {
 
   override def beforeEach {
     Mockito.reset(mockRenderer)
   }
 
-  val userAnswersId = "id"
-  val eoriNumber: EoriNumber       = EoriNumber("EoriNumber")
+  val userAnswersId             = "id"
+  val eoriNumber: EoriNumber    = EoriNumber("EoriNumber")
   val lrn: LocalReferenceNumber = LocalReferenceNumber("ABCD1234567890123").get
 
   val emptyUserAnswers: UserAnswers = UserAnswers(lrn, eoriNumber, Json.obj())
 
-  def injector: Injector = app.injector
-
-  def frontendAppConfig: FrontendAppConfig = injector.instanceOf[FrontendAppConfig]
-
-  def messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
-
-  def fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("", "")
-
   val mockRenderer: NunjucksRenderer = mock[NunjucksRenderer]
 
-  implicit def messages: Messages = messagesApi.preferred(fakeRequest)
+  implicit def messages: Messages = Helpers.stubMessages()
 
   protected def applicationBuilder(userAnswers: Option[UserAnswers] = None): GuiceApplicationBuilder =
     new GuiceApplicationBuilder()
       .overrides(
         bind[DataRequiredAction].to[DataRequiredActionImpl],
         bind[IdentifierAction].to[FakeIdentifierAction],
-        bind[DataRetrievalActionProvider].toInstance(new FakeDataRetrievalActionProvider(userAnswers)),
-        bind[NunjucksRenderer].toInstance(mockRenderer)
+        bind[DataRetrievalActionProvider]
+          .toInstance(new FakeDataRetrievalActionProvider(userAnswers)),
+        bind[NunjucksRenderer].toInstance(mockRenderer),
+        bind[MessagesApi].toInstance(Helpers.stubMessagesApi())
       )
 }

--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -20,11 +20,10 @@ import base.SpecBase
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.JsObject
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.twirl.api.Html
-import uk.gov.hmrc.viewmodels.SummaryList
 
 import scala.concurrent.Future
 
@@ -37,9 +36,11 @@ class CheckYourAnswersControllerSpec extends SpecBase {
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
-      val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad(lrn).url)
+      val request =
+        FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad(lrn).url)
 
       val result = route(application, request).value
 
@@ -48,7 +49,8 @@ class CheckYourAnswersControllerSpec extends SpecBase {
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
       templateCaptor.getValue mustEqual "check-your-answers.njk"
 
@@ -59,13 +61,16 @@ class CheckYourAnswersControllerSpec extends SpecBase {
 
       val application = applicationBuilder(userAnswers = None).build()
 
-      val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad(lrn).url)
+      val request =
+        FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad(lrn).url)
 
       val result = route(application, request).value
 
       status(result) mustEqual SEE_OTHER
 
-      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+      redirectLocation(result).value mustEqual routes.SessionExpiredController
+        .onPageLoad()
+        .url
 
       application.stop()
     }

--- a/test/controllers/DeclarationPlaceControllerSpec.scala
+++ b/test/controllers/DeclarationPlaceControllerSpec.scala
@@ -19,16 +19,15 @@ package controllers
 import base.SpecBase
 import forms.DeclarationPlaceFormProvider
 import matchers.JsonMatchers
-import models.{NormalMode, UserAnswers}
+import models.NormalMode
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
 import pages.DeclarationPlacePage
-import play.api.data.Form
 import play.api.inject.bind
-import play.api.libs.json.{JsObject, JsString, Json}
+import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -38,14 +37,19 @@ import uk.gov.hmrc.viewmodels.NunjucksSupport
 
 import scala.concurrent.Future
 
-class DeclarationPlaceControllerSpec extends SpecBase with MockitoSugar with NunjucksSupport with JsonMatchers {
+class DeclarationPlaceControllerSpec
+    extends SpecBase
+    with MockitoSugar
+    with NunjucksSupport
+    with JsonMatchers {
 
   def onwardRoute = Call("GET", "/foo")
 
   val formProvider = new DeclarationPlaceFormProvider()
   val form = formProvider()
 
-  lazy val declarationPlaceRoute = routes.DeclarationPlaceController.onPageLoad(lrn, NormalMode).url
+  lazy val declarationPlaceRoute =
+    routes.DeclarationPlaceController.onPageLoad(lrn, NormalMode).url
 
   "DeclarationPlace Controller" - {
 
@@ -54,7 +58,8 @@ class DeclarationPlaceControllerSpec extends SpecBase with MockitoSugar with Nun
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
       val request = FakeRequest(GET, declarationPlaceRoute)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
@@ -63,13 +68,11 @@ class DeclarationPlaceControllerSpec extends SpecBase with MockitoSugar with Nun
 
       status(result) mustEqual OK
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
-      val expectedJson = Json.obj(
-        "form"   -> form,
-        "mode"   -> NormalMode,
-        "lrn"    -> lrn
-      )
+      val expectedJson =
+        Json.obj("form" -> form, "mode" -> NormalMode, "lrn" -> lrn)
 
       templateCaptor.getValue mustEqual "declarationPlace.njk"
       jsonCaptor.getValue must containJson(expectedJson)
@@ -82,8 +85,10 @@ class DeclarationPlaceControllerSpec extends SpecBase with MockitoSugar with Nun
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val userAnswers = emptyUserAnswers.set(DeclarationPlacePage, "answer").success.value
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+      val userAnswers =
+        emptyUserAnswers.set(DeclarationPlacePage, "answer").success.value
+      val application =
+        applicationBuilder(userAnswers = Some(userAnswers)).build()
       val request = FakeRequest(GET, declarationPlaceRoute)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
@@ -92,15 +97,13 @@ class DeclarationPlaceControllerSpec extends SpecBase with MockitoSugar with Nun
 
       status(result) mustEqual OK
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
       val filledForm = form.bind(Map("value" -> "answer"))
 
-      val expectedJson = Json.obj(
-        "form" -> filledForm,
-        "lrn"  -> lrn,
-        "mode" -> NormalMode
-      )
+      val expectedJson =
+        Json.obj("form" -> filledForm, "lrn" -> lrn, "mode" -> NormalMode)
 
       templateCaptor.getValue mustEqual "declarationPlace.njk"
 
@@ -140,8 +143,10 @@ class DeclarationPlaceControllerSpec extends SpecBase with MockitoSugar with Nun
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
-      val request = FakeRequest(POST, declarationPlaceRoute).withFormUrlEncodedBody(("value", ""))
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val request = FakeRequest(POST, declarationPlaceRoute)
+        .withFormUrlEncodedBody(("value", ""))
       val boundForm = form.bind(Map("value" -> ""))
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
@@ -150,13 +155,11 @@ class DeclarationPlaceControllerSpec extends SpecBase with MockitoSugar with Nun
 
       status(result) mustEqual BAD_REQUEST
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
-      val expectedJson = Json.obj(
-        "form" -> boundForm,
-        "lrn"  -> lrn,
-        "mode" -> NormalMode
-      )
+      val expectedJson =
+        Json.obj("form" -> boundForm, "lrn" -> lrn, "mode" -> NormalMode)
 
       templateCaptor.getValue mustEqual "declarationPlace.njk"
       jsonCaptor.getValue must containJson(expectedJson)
@@ -174,7 +177,9 @@ class DeclarationPlaceControllerSpec extends SpecBase with MockitoSugar with Nun
 
       status(result) mustEqual SEE_OTHER
 
-      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+      redirectLocation(result).value mustEqual routes.SessionExpiredController
+        .onPageLoad()
+        .url
 
       application.stop()
     }
@@ -191,7 +196,9 @@ class DeclarationPlaceControllerSpec extends SpecBase with MockitoSugar with Nun
 
       status(result) mustEqual SEE_OTHER
 
-      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+      redirectLocation(result).value mustEqual routes.SessionExpiredController
+        .onPageLoad()
+        .url
 
       application.stop()
     }

--- a/test/controllers/DeclarationSummaryControllerSpec.scala
+++ b/test/controllers/DeclarationSummaryControllerSpec.scala
@@ -17,12 +17,16 @@
 package controllers
 
 import base.SpecBase
+import config.FrontendAppConfig
 import matchers.JsonMatchers
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{times, verify, when}
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.JsObject
+import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.twirl.api.Html
@@ -37,10 +41,12 @@ class DeclarationSummaryControllerSpec extends SpecBase with MockitoSugar with J
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
-      val request = FakeRequest(GET, routes.DeclarationSummaryController.onPageLoad(lrn).url)
+      val application       = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val frontendAppConfig = application.injector.instanceOf[FrontendAppConfig]
+
+      val request        = FakeRequest(GET, routes.DeclarationSummaryController.onPageLoad(lrn).url)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
-      val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
+      val jsonCaptor     = ArgumentCaptor.forClass(classOf[JsObject])
 
       val result = route(application, request).value
 
@@ -48,8 +54,11 @@ class DeclarationSummaryControllerSpec extends SpecBase with MockitoSugar with J
 
       verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
-      val expectedJson = Json.obj("lrn" -> lrn,
-        "backToTransitMovements" -> frontendAppConfig.manageTransitMovementsUrl)
+      val expectedJson =
+        Json.obj(
+          "lrn"                    -> lrn,
+          "backToTransitMovements" -> frontendAppConfig.manageTransitMovementsUrl
+        )
 
       templateCaptor.getValue mustEqual "declarationSummary.njk"
       jsonCaptor.getValue must containJson(expectedJson)
@@ -57,6 +66,5 @@ class DeclarationSummaryControllerSpec extends SpecBase with MockitoSugar with J
       application.stop()
     }
   }
-
 
 }

--- a/test/controllers/DeclarationTypeControllerSpec.scala
+++ b/test/controllers/DeclarationTypeControllerSpec.scala
@@ -19,15 +19,20 @@ package controllers
 import base.SpecBase
 import forms.DeclarationTypeFormProvider
 import matchers.JsonMatchers
-import models.{NormalMode, DeclarationType, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import models.NormalMode
+import models.DeclarationType
+import navigation.FakeNavigator
+import navigation.Navigator
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{times, verify, when}
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import pages.DeclarationTypePage
 import play.api.inject.bind
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.JsObject
+import play.api.libs.json.Json
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -44,7 +49,7 @@ class DeclarationTypeControllerSpec extends SpecBase with MockitoSugar with Nunj
   lazy val declarationTypeRoute = routes.DeclarationTypeController.onPageLoad(lrn, NormalMode).url
 
   val formProvider = new DeclarationTypeFormProvider()
-  val form = formProvider()
+  val form         = formProvider()
 
   "DeclarationType Controller" - {
 
@@ -53,10 +58,10 @@ class DeclarationTypeControllerSpec extends SpecBase with MockitoSugar with Nunj
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
-      val request = FakeRequest(GET, declarationTypeRoute)
+      val application    = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val request        = FakeRequest(GET, declarationTypeRoute)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
-      val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
+      val jsonCaptor     = ArgumentCaptor.forClass(classOf[JsObject])
 
       val result = route(application, request).value
 
@@ -82,11 +87,11 @@ class DeclarationTypeControllerSpec extends SpecBase with MockitoSugar with Nunj
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val userAnswers = emptyUserAnswers.set(DeclarationTypePage, DeclarationType.values.head).success.value
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
-      val request = FakeRequest(GET, declarationTypeRoute)
+      val userAnswers    = emptyUserAnswers.set(DeclarationTypePage, DeclarationType.values.head).success.value
+      val application    = applicationBuilder(userAnswers = Some(userAnswers)).build()
+      val request        = FakeRequest(GET, declarationTypeRoute)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
-      val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
+      val jsonCaptor     = ArgumentCaptor.forClass(classOf[JsObject])
 
       val result = route(application, request).value
 
@@ -141,11 +146,11 @@ class DeclarationTypeControllerSpec extends SpecBase with MockitoSugar with Nunj
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
-      val request = FakeRequest(POST, declarationTypeRoute).withFormUrlEncodedBody(("value", "invalid value"))
-      val boundForm = form.bind(Map("value" -> "invalid value"))
+      val application    = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val request        = FakeRequest(POST, declarationTypeRoute).withFormUrlEncodedBody(("value", "invalid value"))
+      val boundForm      = form.bind(Map("value" -> "invalid value"))
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
-      val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
+      val jsonCaptor     = ArgumentCaptor.forClass(classOf[JsObject])
 
       val result = route(application, request).value
 

--- a/test/controllers/LocalReferenceNumberControllerSpec.scala
+++ b/test/controllers/LocalReferenceNumberControllerSpec.scala
@@ -19,15 +19,13 @@ package controllers
 import base.SpecBase
 import forms.LocalReferenceNumberFormProvider
 import matchers.JsonMatchers
-import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
-import pages.LocalReferenceNumberPage
 import play.api.inject.bind
-import play.api.libs.json.{JsObject, JsString, Json}
+import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -37,14 +35,19 @@ import uk.gov.hmrc.viewmodels.NunjucksSupport
 
 import scala.concurrent.Future
 
-class LocalReferenceNumberControllerSpec extends SpecBase with MockitoSugar with NunjucksSupport with JsonMatchers {
+class LocalReferenceNumberControllerSpec
+    extends SpecBase
+    with MockitoSugar
+    with NunjucksSupport
+    with JsonMatchers {
 
   def onwardRoute: Call = Call("GET", "/foo")
 
   val formProvider = new LocalReferenceNumberFormProvider()
   val form = formProvider()
 
-  lazy val localReferenceNumberRoute: String = routes.LocalReferenceNumberController.onPageLoad.url
+  lazy val localReferenceNumberRoute: String =
+    routes.LocalReferenceNumberController.onPageLoad.url
 
   "LocalReferenceNumber Controller" - {
 
@@ -53,7 +56,8 @@ class LocalReferenceNumberControllerSpec extends SpecBase with MockitoSugar with
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
       val request = FakeRequest(GET, localReferenceNumberRoute)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
@@ -62,11 +66,10 @@ class LocalReferenceNumberControllerSpec extends SpecBase with MockitoSugar with
 
       status(result) mustEqual OK
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
-      val expectedJson = Json.obj(
-        "form" -> form
-      )
+      val expectedJson = Json.obj("form" -> form)
 
       templateCaptor.getValue mustEqual "localReferenceNumber.njk"
       jsonCaptor.getValue must containJson(expectedJson)
@@ -78,7 +81,8 @@ class LocalReferenceNumberControllerSpec extends SpecBase with MockitoSugar with
 
       val mockSessionRepository = mock[SessionRepository]
 
-      when(mockSessionRepository.get(any(), any())) thenReturn Future.successful(Some(emptyUserAnswers))
+      when(mockSessionRepository.get(any(), any())) thenReturn Future
+        .successful(Some(emptyUserAnswers))
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
 
       val application =
@@ -106,8 +110,10 @@ class LocalReferenceNumberControllerSpec extends SpecBase with MockitoSugar with
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
-      val request = FakeRequest(POST, localReferenceNumberRoute).withFormUrlEncodedBody(("value", ""))
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val request = FakeRequest(POST, localReferenceNumberRoute)
+        .withFormUrlEncodedBody(("value", ""))
       val boundForm = form.bind(Map("value" -> ""))
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
@@ -116,11 +122,10 @@ class LocalReferenceNumberControllerSpec extends SpecBase with MockitoSugar with
 
       status(result) mustEqual BAD_REQUEST
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
-      val expectedJson = Json.obj(
-        "form" -> boundForm
-      )
+      val expectedJson = Json.obj("form" -> boundForm)
 
       templateCaptor.getValue mustEqual "localReferenceNumber.njk"
       jsonCaptor.getValue must containJson(expectedJson)

--- a/test/controllers/ProcedureTypeControllerSpec.scala
+++ b/test/controllers/ProcedureTypeControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import base.SpecBase
 import forms.ProcedureTypeFormProvider
 import matchers.JsonMatchers
-import models.{NormalMode, ProcedureType, UserAnswers}
+import models.{NormalMode, ProcedureType}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -37,11 +37,16 @@ import uk.gov.hmrc.viewmodels.NunjucksSupport
 
 import scala.concurrent.Future
 
-class ProcedureTypeControllerSpec extends SpecBase with MockitoSugar with NunjucksSupport with JsonMatchers {
+class ProcedureTypeControllerSpec
+    extends SpecBase
+    with MockitoSugar
+    with NunjucksSupport
+    with JsonMatchers {
 
   def onwardRoute = Call("GET", "/foo")
 
-  lazy val procedureTypeRoute = routes.ProcedureTypeController.onPageLoad(lrn, NormalMode).url
+  lazy val procedureTypeRoute =
+    routes.ProcedureTypeController.onPageLoad(lrn, NormalMode).url
 
   val formProvider = new ProcedureTypeFormProvider()
   val form = formProvider()
@@ -53,7 +58,8 @@ class ProcedureTypeControllerSpec extends SpecBase with MockitoSugar with Nunjuc
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
       val request = FakeRequest(GET, procedureTypeRoute)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
@@ -62,12 +68,13 @@ class ProcedureTypeControllerSpec extends SpecBase with MockitoSugar with Nunjuc
 
       status(result) mustEqual OK
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
       val expectedJson = Json.obj(
-        "form"   -> form,
-        "mode"   -> NormalMode,
-        "lrn"    -> lrn,
+        "form" -> form,
+        "mode" -> NormalMode,
+        "lrn" -> lrn,
         "radios" -> ProcedureType.radios(form)
       )
 
@@ -82,8 +89,12 @@ class ProcedureTypeControllerSpec extends SpecBase with MockitoSugar with Nunjuc
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val userAnswers = emptyUserAnswers.set(ProcedureTypePage, ProcedureType.values.head).success.value
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+      val userAnswers = emptyUserAnswers
+        .set(ProcedureTypePage, ProcedureType.values.head)
+        .success
+        .value
+      val application =
+        applicationBuilder(userAnswers = Some(userAnswers)).build()
       val request = FakeRequest(GET, procedureTypeRoute)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
@@ -92,14 +103,16 @@ class ProcedureTypeControllerSpec extends SpecBase with MockitoSugar with Nunjuc
 
       status(result) mustEqual OK
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
-      val filledForm = form.bind(Map("value" -> ProcedureType.values.head.toString))
+      val filledForm =
+        form.bind(Map("value" -> ProcedureType.values.head.toString))
 
       val expectedJson = Json.obj(
-        "form"   -> filledForm,
-        "mode"   -> NormalMode,
-        "lrn"    -> lrn,
+        "form" -> filledForm,
+        "mode" -> NormalMode,
+        "lrn" -> lrn,
         "radios" -> ProcedureType.radios(filledForm)
       )
 
@@ -141,8 +154,10 @@ class ProcedureTypeControllerSpec extends SpecBase with MockitoSugar with Nunjuc
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
-      val request = FakeRequest(POST, procedureTypeRoute).withFormUrlEncodedBody(("value", "invalid value"))
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val request = FakeRequest(POST, procedureTypeRoute)
+        .withFormUrlEncodedBody(("value", "invalid value"))
       val boundForm = form.bind(Map("value" -> "invalid value"))
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
@@ -151,12 +166,13 @@ class ProcedureTypeControllerSpec extends SpecBase with MockitoSugar with Nunjuc
 
       status(result) mustEqual BAD_REQUEST
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
       val expectedJson = Json.obj(
-        "form"   -> boundForm,
-        "mode"   -> NormalMode,
-        "lrn"    -> lrn,
+        "form" -> boundForm,
+        "mode" -> NormalMode,
+        "lrn" -> lrn,
         "radios" -> ProcedureType.radios(boundForm)
       )
 
@@ -175,7 +191,9 @@ class ProcedureTypeControllerSpec extends SpecBase with MockitoSugar with Nunjuc
       val result = route(application, request).value
 
       status(result) mustEqual SEE_OTHER
-      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+      redirectLocation(result).value mustEqual routes.SessionExpiredController
+        .onPageLoad()
+        .url
 
       application.stop()
     }
@@ -192,7 +210,9 @@ class ProcedureTypeControllerSpec extends SpecBase with MockitoSugar with Nunjuc
 
       status(result) mustEqual SEE_OTHER
 
-      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+      redirectLocation(result).value mustEqual routes.SessionExpiredController
+        .onPageLoad()
+        .url
 
       application.stop()
     }

--- a/test/controllers/RepresentativeCapacityControllerSpec.scala
+++ b/test/controllers/RepresentativeCapacityControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import base.SpecBase
 import forms.RepresentativeCapacityFormProvider
 import matchers.JsonMatchers
-import models.{NormalMode, RepresentativeCapacity, UserAnswers}
+import models.{NormalMode, RepresentativeCapacity}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -37,11 +37,16 @@ import uk.gov.hmrc.viewmodels.NunjucksSupport
 
 import scala.concurrent.Future
 
-class RepresentativeCapacityControllerSpec extends SpecBase with MockitoSugar with NunjucksSupport with JsonMatchers {
+class RepresentativeCapacityControllerSpec
+    extends SpecBase
+    with MockitoSugar
+    with NunjucksSupport
+    with JsonMatchers {
 
   def onwardRoute = Call("GET", "/foo")
 
-  lazy val representativeCapacityRoute = routes.RepresentativeCapacityController.onPageLoad(lrn, NormalMode).url
+  lazy val representativeCapacityRoute =
+    routes.RepresentativeCapacityController.onPageLoad(lrn, NormalMode).url
 
   val formProvider = new RepresentativeCapacityFormProvider()
   val form = formProvider()
@@ -53,7 +58,8 @@ class RepresentativeCapacityControllerSpec extends SpecBase with MockitoSugar wi
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
       val request = FakeRequest(GET, representativeCapacityRoute)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
@@ -62,12 +68,13 @@ class RepresentativeCapacityControllerSpec extends SpecBase with MockitoSugar wi
 
       status(result) mustEqual OK
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
       val expectedJson = Json.obj(
-        "form"   -> form,
-        "mode"   -> NormalMode,
-        "lrn"    -> lrn,
+        "form" -> form,
+        "mode" -> NormalMode,
+        "lrn" -> lrn,
         "radios" -> RepresentativeCapacity.radios(form)
       )
 
@@ -82,8 +89,12 @@ class RepresentativeCapacityControllerSpec extends SpecBase with MockitoSugar wi
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val userAnswers = emptyUserAnswers.set(RepresentativeCapacityPage, RepresentativeCapacity.values.head).success.value
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+      val userAnswers = emptyUserAnswers
+        .set(RepresentativeCapacityPage, RepresentativeCapacity.values.head)
+        .success
+        .value
+      val application =
+        applicationBuilder(userAnswers = Some(userAnswers)).build()
       val request = FakeRequest(GET, representativeCapacityRoute)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
@@ -92,14 +103,16 @@ class RepresentativeCapacityControllerSpec extends SpecBase with MockitoSugar wi
 
       status(result) mustEqual OK
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
-      val filledForm = form.bind(Map("value" -> RepresentativeCapacity.values.head.toString))
+      val filledForm =
+        form.bind(Map("value" -> RepresentativeCapacity.values.head.toString))
 
       val expectedJson = Json.obj(
-        "form"   -> filledForm,
-        "mode"   -> NormalMode,
-        "lrn"    -> lrn,
+        "form" -> filledForm,
+        "mode" -> NormalMode,
+        "lrn" -> lrn,
         "radios" -> RepresentativeCapacity.radios(filledForm)
       )
 
@@ -125,7 +138,9 @@ class RepresentativeCapacityControllerSpec extends SpecBase with MockitoSugar wi
 
       val request =
         FakeRequest(POST, representativeCapacityRoute)
-          .withFormUrlEncodedBody(("value", RepresentativeCapacity.values.head.toString))
+          .withFormUrlEncodedBody(
+            ("value", RepresentativeCapacity.values.head.toString)
+          )
 
       val result = route(application, request).value
 
@@ -141,8 +156,10 @@ class RepresentativeCapacityControllerSpec extends SpecBase with MockitoSugar wi
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
-      val request = FakeRequest(POST, representativeCapacityRoute).withFormUrlEncodedBody(("value", "invalid value"))
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val request = FakeRequest(POST, representativeCapacityRoute)
+        .withFormUrlEncodedBody(("value", "invalid value"))
       val boundForm = form.bind(Map("value" -> "invalid value"))
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
@@ -151,12 +168,13 @@ class RepresentativeCapacityControllerSpec extends SpecBase with MockitoSugar wi
 
       status(result) mustEqual BAD_REQUEST
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
       val expectedJson = Json.obj(
-        "form"   -> boundForm,
-        "mode"   -> NormalMode,
-        "lrn"    -> lrn,
+        "form" -> boundForm,
+        "mode" -> NormalMode,
+        "lrn" -> lrn,
         "radios" -> RepresentativeCapacity.radios(boundForm)
       )
 
@@ -175,7 +193,9 @@ class RepresentativeCapacityControllerSpec extends SpecBase with MockitoSugar wi
       val result = route(application, request).value
 
       status(result) mustEqual SEE_OTHER
-      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+      redirectLocation(result).value mustEqual routes.SessionExpiredController
+        .onPageLoad()
+        .url
 
       application.stop()
     }
@@ -186,13 +206,17 @@ class RepresentativeCapacityControllerSpec extends SpecBase with MockitoSugar wi
 
       val request =
         FakeRequest(POST, representativeCapacityRoute)
-          .withFormUrlEncodedBody(("value", RepresentativeCapacity.values.head.toString))
+          .withFormUrlEncodedBody(
+            ("value", RepresentativeCapacity.values.head.toString)
+          )
 
       val result = route(application, request).value
 
       status(result) mustEqual SEE_OTHER
 
-      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+      redirectLocation(result).value mustEqual routes.SessionExpiredController
+        .onPageLoad()
+        .url
 
       application.stop()
     }

--- a/test/controllers/RepresentativeNameControllerSpec.scala
+++ b/test/controllers/RepresentativeNameControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import base.SpecBase
 import forms.RepresentativeNameFormProvider
 import matchers.JsonMatchers
-import models.{NormalMode, UserAnswers}
+import models.NormalMode
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -27,7 +27,7 @@ import org.mockito.Mockito.{times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
 import pages.RepresentativeNamePage
 import play.api.inject.bind
-import play.api.libs.json.{JsObject, JsString, Json}
+import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -37,14 +37,19 @@ import uk.gov.hmrc.viewmodels.NunjucksSupport
 
 import scala.concurrent.Future
 
-class RepresentativeNameControllerSpec extends SpecBase with MockitoSugar with NunjucksSupport with JsonMatchers {
+class RepresentativeNameControllerSpec
+    extends SpecBase
+    with MockitoSugar
+    with NunjucksSupport
+    with JsonMatchers {
 
   def onwardRoute = Call("GET", "/foo")
 
   val formProvider = new RepresentativeNameFormProvider()
   val form = formProvider()
 
-  lazy val representativeNameRoute = routes.RepresentativeNameController.onPageLoad(lrn, NormalMode).url
+  lazy val representativeNameRoute =
+    routes.RepresentativeNameController.onPageLoad(lrn, NormalMode).url
 
   "RepresentativeName Controller" - {
 
@@ -53,7 +58,8 @@ class RepresentativeNameControllerSpec extends SpecBase with MockitoSugar with N
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
       val request = FakeRequest(GET, representativeNameRoute)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
@@ -62,13 +68,11 @@ class RepresentativeNameControllerSpec extends SpecBase with MockitoSugar with N
 
       status(result) mustEqual OK
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
-      val expectedJson = Json.obj(
-        "form"   -> form,
-        "mode"   -> NormalMode,
-        "lrn"    -> lrn
-      )
+      val expectedJson =
+        Json.obj("form" -> form, "mode" -> NormalMode, "lrn" -> lrn)
 
       templateCaptor.getValue mustEqual "representativeName.njk"
       jsonCaptor.getValue must containJson(expectedJson)
@@ -81,8 +85,10 @@ class RepresentativeNameControllerSpec extends SpecBase with MockitoSugar with N
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val userAnswers = emptyUserAnswers.set(RepresentativeNamePage, "answer").success.value
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+      val userAnswers =
+        emptyUserAnswers.set(RepresentativeNamePage, "answer").success.value
+      val application =
+        applicationBuilder(userAnswers = Some(userAnswers)).build()
       val request = FakeRequest(GET, representativeNameRoute)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
@@ -91,15 +97,13 @@ class RepresentativeNameControllerSpec extends SpecBase with MockitoSugar with N
 
       status(result) mustEqual OK
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
       val filledForm = form.bind(Map("value" -> "answer"))
 
-      val expectedJson = Json.obj(
-        "form" -> filledForm,
-        "lrn"  -> lrn,
-        "mode" -> NormalMode
-      )
+      val expectedJson =
+        Json.obj("form" -> filledForm, "lrn" -> lrn, "mode" -> NormalMode)
 
       templateCaptor.getValue mustEqual "representativeName.njk"
       jsonCaptor.getValue must containJson(expectedJson)
@@ -138,8 +142,10 @@ class RepresentativeNameControllerSpec extends SpecBase with MockitoSugar with N
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
-      val request = FakeRequest(POST, representativeNameRoute).withFormUrlEncodedBody(("value", ""))
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val request = FakeRequest(POST, representativeNameRoute)
+        .withFormUrlEncodedBody(("value", ""))
       val boundForm = form.bind(Map("value" -> ""))
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor = ArgumentCaptor.forClass(classOf[JsObject])
@@ -148,13 +154,11 @@ class RepresentativeNameControllerSpec extends SpecBase with MockitoSugar with N
 
       status(result) mustEqual BAD_REQUEST
 
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+      verify(mockRenderer, times(1))
+        .render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
-      val expectedJson = Json.obj(
-        "form" -> boundForm,
-        "lrn"  -> lrn,
-        "mode" -> NormalMode
-      )
+      val expectedJson =
+        Json.obj("form" -> boundForm, "lrn" -> lrn, "mode" -> NormalMode)
 
       templateCaptor.getValue mustEqual "representativeName.njk"
       jsonCaptor.getValue must containJson(expectedJson)
@@ -172,7 +176,9 @@ class RepresentativeNameControllerSpec extends SpecBase with MockitoSugar with N
 
       status(result) mustEqual SEE_OTHER
 
-      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+      redirectLocation(result).value mustEqual routes.SessionExpiredController
+        .onPageLoad()
+        .url
 
       application.stop()
     }
@@ -189,7 +195,9 @@ class RepresentativeNameControllerSpec extends SpecBase with MockitoSugar with N
 
       status(result) mustEqual SEE_OTHER
 
-      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+      redirectLocation(result).value mustEqual routes.SessionExpiredController
+        .onPageLoad()
+        .url
 
       application.stop()
     }

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -18,10 +18,17 @@ package controllers.actions
 
 import base.SpecBase
 import com.google.inject.Inject
+import config.FrontendAppConfig
 import controllers.routes
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, when}
-import play.api.mvc.{Action, AnyContent, BodyParsers, Results}
+import org.mockito.Mockito.reset
+import org.mockito.Mockito.when
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.AnyContentAsEmpty
+import play.api.mvc.BodyParsers
+import play.api.mvc.Results
+import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.Predicate
@@ -29,12 +36,19 @@ import uk.gov.hmrc.auth.core.retrieve.Retrieval
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 class AuthActionSpec extends SpecBase {
 
+  private def fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("", "")
+
   class Harness(authAction: IdentifierAction) {
-    def onPageLoad(): Action[AnyContent] = authAction { _ => Results.Ok }
+
+    def onPageLoad(): Action[AnyContent] =
+      authAction {
+        _ => Results.Ok
+      }
   }
 
   val mockAuthConnector: AuthConnector = mock[AuthConnector]
@@ -105,13 +119,14 @@ class AuthActionSpec extends SpecBase {
 
       "must redirect the user to log in " in {
 
-        val application = applicationBuilder(userAnswers = None).build()
+        val application       = applicationBuilder(userAnswers = None).build()
+        val frontendAppConfig = application.injector.instanceOf[FrontendAppConfig]
 
         val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new MissingBearerToken), frontendAppConfig, bodyParsers)
         val controller = new Harness(authAction)
-        val result = controller.onPageLoad()(fakeRequest)
+        val result     = controller.onPageLoad()(fakeRequest)
 
         status(result) mustBe SEE_OTHER
 
@@ -123,13 +138,14 @@ class AuthActionSpec extends SpecBase {
 
       "must redirect the user to log in " in {
 
-        val application = applicationBuilder(userAnswers = None).build()
+        val application       = applicationBuilder(userAnswers = None).build()
+        val frontendAppConfig = application.injector.instanceOf[FrontendAppConfig]
 
         val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new BearerTokenExpired), frontendAppConfig, bodyParsers)
         val controller = new Harness(authAction)
-        val result = controller.onPageLoad()(fakeRequest)
+        val result     = controller.onPageLoad()(fakeRequest)
 
         status(result) mustBe SEE_OTHER
 
@@ -141,13 +157,14 @@ class AuthActionSpec extends SpecBase {
 
       "must redirect the user to the unauthorised page" in {
 
-        val application = applicationBuilder(userAnswers = None).build()
+        val application       = applicationBuilder(userAnswers = None).build()
+        val frontendAppConfig = application.injector.instanceOf[FrontendAppConfig]
 
         val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new InsufficientEnrolments), frontendAppConfig, bodyParsers)
         val controller = new Harness(authAction)
-        val result = controller.onPageLoad()(fakeRequest)
+        val result     = controller.onPageLoad()(fakeRequest)
 
         status(result) mustBe SEE_OTHER
 
@@ -159,13 +176,14 @@ class AuthActionSpec extends SpecBase {
 
       "must redirect the user to the unauthorised page" in {
 
-        val application = applicationBuilder(userAnswers = None).build()
+        val application       = applicationBuilder(userAnswers = None).build()
+        val frontendAppConfig = application.injector.instanceOf[FrontendAppConfig]
 
         val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new InsufficientConfidenceLevel), frontendAppConfig, bodyParsers)
         val controller = new Harness(authAction)
-        val result = controller.onPageLoad()(fakeRequest)
+        val result     = controller.onPageLoad()(fakeRequest)
 
         status(result) mustBe SEE_OTHER
 
@@ -177,13 +195,14 @@ class AuthActionSpec extends SpecBase {
 
       "must redirect the user to the unauthorised page" in {
 
-        val application = applicationBuilder(userAnswers = None).build()
+        val application       = applicationBuilder(userAnswers = None).build()
+        val frontendAppConfig = application.injector.instanceOf[FrontendAppConfig]
 
         val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedAuthProvider), frontendAppConfig, bodyParsers)
         val controller = new Harness(authAction)
-        val result = controller.onPageLoad()(fakeRequest)
+        val result     = controller.onPageLoad()(fakeRequest)
 
         status(result) mustBe SEE_OTHER
 
@@ -195,13 +214,14 @@ class AuthActionSpec extends SpecBase {
 
       "must redirect the user to the unauthorised page" in {
 
-        val application = applicationBuilder(userAnswers = None).build()
+        val application       = applicationBuilder(userAnswers = None).build()
+        val frontendAppConfig = application.injector.instanceOf[FrontendAppConfig]
 
         val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedAffinityGroup), frontendAppConfig, bodyParsers)
         val controller = new Harness(authAction)
-        val result = controller.onPageLoad()(fakeRequest)
+        val result     = controller.onPageLoad()(fakeRequest)
 
         status(result) mustBe SEE_OTHER
 
@@ -213,13 +233,14 @@ class AuthActionSpec extends SpecBase {
 
       "must redirect the user to the unauthorised page" in {
 
-        val application = applicationBuilder(userAnswers = None).build()
+        val application       = applicationBuilder(userAnswers = None).build()
+        val frontendAppConfig = application.injector.instanceOf[FrontendAppConfig]
 
         val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedCredentialRole), frontendAppConfig, bodyParsers)
         val controller = new Harness(authAction)
-        val result = controller.onPageLoad()(fakeRequest)
+        val result     = controller.onPageLoad()(fakeRequest)
 
         status(result) mustBe SEE_OTHER
 
@@ -233,13 +254,14 @@ class AuthActionSpec extends SpecBase {
         when(mockAuthConnector.authorise[Enrolments](any(), any())(any(), any()))
           .thenReturn(Future.successful(enrolmentsWithoutEori))
 
-        val application = applicationBuilder(userAnswers = None).build()
+        val application       = applicationBuilder(userAnswers = None).build()
+        val frontendAppConfig = application.injector.instanceOf[FrontendAppConfig]
 
         val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(mockAuthConnector, frontendAppConfig, bodyParsers)
         val controller = new Harness(authAction)
-        val result = controller.onPageLoad()(fakeRequest)
+        val result     = controller.onPageLoad()(fakeRequest)
 
         status(result) mustBe SEE_OTHER
 
@@ -251,13 +273,14 @@ class AuthActionSpec extends SpecBase {
         when(mockAuthConnector.authorise[Enrolments](any(), any())(any(), any()))
           .thenReturn(Future.successful(enrolmentsWithEori))
 
-        val application = applicationBuilder(userAnswers = None).build()
+        val application       = applicationBuilder(userAnswers = None).build()
+        val frontendAppConfig = application.injector.instanceOf[FrontendAppConfig]
 
         val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(mockAuthConnector, frontendAppConfig, bodyParsers)
         val controller = new Harness(authAction)
-        val result = controller.onPageLoad()(fakeRequest)
+        val result     = controller.onPageLoad()(fakeRequest)
 
         status(result) mustBe OK
       }
@@ -270,7 +293,7 @@ class AuthActionSpec extends SpecBase {
   }
 }
 
-class FakeFailingAuthConnector @Inject()(exceptionToReturn: Throwable) extends AuthConnector {
+class FakeFailingAuthConnector @Inject() (exceptionToReturn: Throwable) extends AuthConnector {
   val serviceUrl: String = ""
 
   override def authorise[A](predicate: Predicate, retrieval: Retrieval[A])(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[A] =

--- a/test/filters/SessionIdFilterSpec.scala
+++ b/test/filters/SessionIdFilterSpec.scala
@@ -20,17 +20,21 @@ import java.util.UUID
 
 import akka.stream.Materializer
 import com.google.inject.Inject
+import org.scalatest.OptionValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.OptionValues
 import org.scalatestplus.play.components.OneAppPerSuiteWithComponents
-import play.api.{Application, BuiltInComponents, BuiltInComponentsFromContext, NoHttpFiltersComponents}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
-import play.api.mvc.{Action, Results, SessionCookieBaker}
-import play.api.routing.Router
+import play.api.mvc.SessionCookieBaker
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import play.api.{
+  Application,
+  BuiltInComponents,
+  BuiltInComponentsFromContext,
+  NoHttpFiltersComponents
+}
 import uk.gov.hmrc.http.{HeaderNames, SessionKeys}
 
 import scala.concurrent.ExecutionContext
@@ -39,40 +43,48 @@ object SessionIdFilterSpec {
 
   val sessionId = "28836767-a008-46be-ac18-695ab140e705"
 
-  class TestSessionIdFilter @Inject()(
-                                       override val mat: Materializer,
-                                       sessionCookieBaker: SessionCookieBaker,
-                                       ec: ExecutionContext
-                                     ) extends SessionIdFilter(mat, UUID.fromString(sessionId), sessionCookieBaker, ec)
+  class TestSessionIdFilter @Inject()(override val mat: Materializer,
+                                      sessionCookieBaker: SessionCookieBaker,
+                                      ec: ExecutionContext)
+      extends SessionIdFilter(
+        mat,
+        UUID.fromString(sessionId),
+        sessionCookieBaker,
+        ec
+      )
 
 }
 
-class SessionIdFilterSpec extends AnyFreeSpec with Matchers with OptionValues with OneAppPerSuiteWithComponents {
+class SessionIdFilterSpec
+    extends AnyFreeSpec
+    with Matchers
+    with OptionValues
+    with OneAppPerSuiteWithComponents {
 
-  override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
+  override def components: BuiltInComponents =
+    new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
 
-    import play.api.mvc.Results
-    import play.api.routing.Router
-    import play.api.routing.sird._
+      import play.api.mvc.Results
+      import play.api.routing.Router
+      import play.api.routing.sird._
 
-    lazy val router: Router = Router.from {
-      case GET(p"/test") => defaultActionBuilder.apply {
-        request =>
-          val fromHeader = request.headers.get(HeaderNames.xSessionId).getOrElse("")
-          val fromSession = request.session.get(SessionKeys.sessionId).getOrElse("")
-          Results.Ok(
-            Json.obj(
-              "fromHeader" -> fromHeader,
-              "fromSession" -> fromSession
+      lazy val router: Router = Router.from {
+        case GET(p"/test") =>
+          defaultActionBuilder.apply { request =>
+            val fromHeader =
+              request.headers.get(HeaderNames.xSessionId).getOrElse("")
+            val fromSession =
+              request.session.get(SessionKeys.sessionId).getOrElse("")
+            Results.Ok(
+              Json.obj("fromHeader" -> fromHeader, "fromSession" -> fromSession)
             )
-          )
-      }
-      case GET(p"/test2") => defaultActionBuilder.apply {
-        implicit request =>
-          Results.Ok.addingToSession("foo" -> "bar")
+          }
+        case GET(p"/test2") =>
+          defaultActionBuilder.apply { implicit request =>
+            Results.Ok.addingToSession("foo" -> "bar")
+          }
       }
     }
-  }
 
   import SessionIdFilterSpec._
 
@@ -81,11 +93,11 @@ class SessionIdFilterSpec extends AnyFreeSpec with Matchers with OptionValues wi
     import play.api.inject._
 
     new GuiceApplicationBuilder()
-      .overrides(
-        bind[SessionIdFilter].to[TestSessionIdFilter]
-      )
+      .overrides(bind[SessionIdFilter].to[TestSessionIdFilter])
       .configure(
-        "play.filters.disabled" -> List("uk.gov.hmrc.play.bootstrap.filters.frontend.crypto.SessionCookieCryptoFilter")
+        "play.filters.disabled" -> List(
+          "uk.gov.hmrc.play.bootstrap.filters.frontend.crypto.SessionCookieCryptoFilter"
+        )
       )
       .router(components.router)
       .build()
@@ -107,7 +119,10 @@ class SessionIdFilterSpec extends AnyFreeSpec with Matchers with OptionValues wi
 
     "must not override a sessionId if one doesn't already exist" in {
 
-      val result = route(app, FakeRequest(GET, "/test").withSession(SessionKeys.sessionId -> "foo")).value
+      val result = route(
+        app,
+        FakeRequest(GET, "/test").withSession(SessionKeys.sessionId -> "foo")
+      ).value
 
       val body = contentAsJson(result)
 
@@ -124,7 +139,8 @@ class SessionIdFilterSpec extends AnyFreeSpec with Matchers with OptionValues wi
 
     "must not override other session values from the request" in {
 
-      val result = route(app, FakeRequest(GET, "/test").withSession("foo" -> "bar")).value
+      val result =
+        route(app, FakeRequest(GET, "/test").withSession("foo" -> "bar")).value
       session(result).data must contain("foo" -> "bar")
     }
   }

--- a/test/forms/DeclarationPlaceFormProviderSpec.scala
+++ b/test/forms/DeclarationPlaceFormProviderSpec.scala
@@ -17,8 +17,6 @@
 package forms
 
 import forms.behaviours.StringFieldBehaviours
-import models.LocalReferenceNumber
-import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import play.api.data.FormError
 
@@ -52,25 +50,24 @@ class DeclarationPlaceFormProviderSpec extends StringFieldBehaviours {
 
       val expectedError = List(FormError(fieldName, lengthKey, Seq(maxLength)))
 
-      forAll(stringsLongerThan(maxLength + 1)) {
-        string =>
-          val result = form.bind(Map(fieldName -> string)).apply(fieldName)
-          result.errors mustBe expectedError
+      forAll(stringsLongerThan(maxLength + 1)) { string =>
+        val result = form.bind(Map(fieldName -> string)).apply(fieldName)
+        result.errors mustBe expectedError
       }
     }
 
     "must not bind strings that do not match regex" in {
 
-      val expectedError = List(FormError(fieldName, invalidKey, Seq(postCodeRegex)))
+      val expectedError =
+        List(FormError(fieldName, invalidKey, Seq(postCodeRegex)))
 
       val genInvalidString: Gen[String] = {
         stringsWithMaxLength(maxLength) suchThat (!_.matches(postCodeRegex))
       }
 
-      forAll(genInvalidString) {
-        invalidString =>
-          val result = form.bind(Map(fieldName -> invalidString)).apply(fieldName)
-          result.errors mustBe expectedError
+      forAll(genInvalidString) { invalidString =>
+        val result = form.bind(Map(fieldName -> invalidString)).apply(fieldName)
+        result.errors mustBe expectedError
       }
     }
   }

--- a/test/matchers/JsonMatchers.scala
+++ b/test/matchers/JsonMatchers.scala
@@ -16,7 +16,8 @@
 
 package matchers
 
-import org.scalatest.matchers.{MatchResult, Matcher}
+import org.scalatest.matchers.MatchResult
+import org.scalatest.matchers.Matcher
 import play.api.libs.json._
 
 trait JsonMatchers {

--- a/test/models/MongoDateTimeFormatsSpec.scala
+++ b/test/models/MongoDateTimeFormatsSpec.scala
@@ -23,31 +23,33 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatest.OptionValues
 import play.api.libs.json.Json
 
-class MongoDateTimeFormatsSpec extends AnyFreeSpec with Matchers with OptionValues with MongoDateTimeFormats {
+class MongoDateTimeFormatsSpec
+    extends AnyFreeSpec
+    with Matchers
+    with OptionValues
+    with MongoDateTimeFormats {
 
   "a LocalDateTime" - {
 
-    val date = LocalDate.of(2018, 2, 1).atStartOfDay
+    val expectedDate = LocalDate.of(2018, 2, 1).atStartOfDay
 
     val dateMillis = 1517443200000L
 
-    val json = Json.obj(
-      "$date" -> dateMillis
-    )
+    val json = Json.obj("$date" -> dateMillis)
 
     "must serialise to json" in {
-      val result = Json.toJson(date)
+      val result = Json.toJson(expectedDate)
       result mustEqual json
     }
 
     "must deserialise from json" in {
       val result = json.as[LocalDateTime]
-      result mustEqual date
+      result mustEqual expectedDate
     }
 
     "must serialise/deserialise to the same value" in {
-      val result = Json.toJson(date).as[LocalDateTime]
-      result mustEqual date
+      val result = Json.toJson(expectedDate).as[LocalDateTime]
+      result mustEqual expectedDate
     }
   }
 }


### PR DESCRIPTION
- Address compiler warnings
- Remove application instance that is created for all tests and use play helpers for Messages and MessagesApi in base test app builder.
