### PR TITLE
Scaffolds fixes

### DIFF
--- a/.g8/checkboxPage/app/controllers/$className$Controller.scala
+++ b/.g8/checkboxPage/app/controllers/$className$Controller.scala
@@ -4,6 +4,8 @@ import controllers.actions._
 import forms.$className$FormProvider
 import javax.inject.Inject
 import models.{Mode, LocalReferenceNumber, $className$}
+import navigation.Navigator
+import navigation.annotations.$navRoute$
 import pages.$className$Page
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json.Json
@@ -18,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class $className$Controller @Inject()(
                                        override val messagesApi: MessagesApi,
                                        sessionRepository: SessionRepository,
-                                       navigator: Navigator,
+                                       @$navRoute$ navigator: Navigator,
                                        identify: IdentifierAction,
                                        getData: DataRetrievalActionProvider,
                                        requireData: DataRequiredAction,
@@ -28,6 +30,7 @@ class $className$Controller @Inject()(
 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with NunjucksSupport {
 
   private val form = formProvider()
+  private val template = "$className;format="decap"$.njk"
 
   def onPageLoad(lrn: LocalReferenceNumber, mode: Mode): Action[AnyContent] = (identify andThen getData(lrn) andThen requireData).async {
     implicit request =>
@@ -44,7 +47,7 @@ class $className$Controller @Inject()(
         "checkboxes" -> $className$.checkboxes(preparedForm)
       )
 
-      renderer.render("$className;format="decap"$.njk", json).map(Ok(_))
+      renderer.render(template, json).map(Ok(_))
   }
 
   def onSubmit(lrn: LocalReferenceNumber, mode: Mode): Action[AnyContent] = (identify andThen getData(lrn) andThen requireData).async {
@@ -60,7 +63,7 @@ class $className$Controller @Inject()(
             "checkboxes" -> $className$.checkboxes(formWithErrors)
           )
 
-          renderer.render("$className;format="decap"$.njk", json).map(BadRequest(_))
+          renderer.render(template, json).map(BadRequest(_))
         },
         value =>
           for {

--- a/.g8/checkboxPage/default.properties
+++ b/.g8/checkboxPage/default.properties
@@ -1,5 +1,6 @@
 description = Generates a controller and view for a page with a set of checkboxes
 className = MyNewPage
+navRoute = PreTaskListDetails
 title = $className;format="decap"$
 option1key = option1
 option1msg = Option 1

--- a/.g8/checkboxPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/checkboxPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -4,7 +4,8 @@ import base.SpecBase
 import forms.$className$FormProvider
 import matchers.JsonMatchers
 import models.{NormalMode, $className$, UserAnswers}
-import navigation.FakeNavigator
+import navigation.{FakeNavigator, Navigator}
+import navigation.annotations.$navRoute$
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
@@ -27,8 +28,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
 
   lazy val $className;format="decap"$Route = routes.$className$Controller.onPageLoad(lrn, NormalMode).url
 
-  val formProvider = new $className$FormProvider()
-  val form = formProvider()
+  private val formProvider = new $className$FormProvider()
+  private val form = formProvider()
+  private val template = "$className;format="decap"$.njk"
+
 
   "$className$ Controller" - {
 
@@ -54,8 +57,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "checkboxes" -> $className$.checkboxes(form)
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }
@@ -85,8 +90,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "checkboxes" -> $className$.checkboxes(filledForm)
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }
@@ -100,7 +107,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind(classOf[Navigator]).qualifiedWith(classOf[PreTaskListDetails]).toInstance(new FakeNavigator(onwardRoute)),
             bind[SessionRepository].toInstance(mockSessionRepository)
           )
           .build()
@@ -142,8 +149,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "checkboxes" -> $className$.checkboxes(boundForm)
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }

--- a/.g8/checkboxPage/migrations/$className__snake$.sh
+++ b/.g8/checkboxPage/migrations/$className__snake$.sh
@@ -22,7 +22,7 @@ echo "$className;format="decap"$.checkYourAnswersLabel = $title$" >> ../conf/mes
 echo "$className;format="decap"$.error.required = Select $className;format="decap"$" >> ../conf/messages.en
 
 echo "Adding to UserAnswersEntryGenerators"
-awk '/trait UserAnswersEntryGenerators/ {\
+awk '/self: Generators =>/ {\
     print;\
     print "";\
     print "  implicit lazy val arbitrary$className$UserAnswersEntry: Arbitrary[($className$Page.type, JsValue)] =";\
@@ -43,7 +43,7 @@ awk '/trait PageGenerators/ {\
     next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
 
 echo "Adding to ModelGenerators"
-awk '/trait ModelGenerators/ {\
+awk '/self: Generators =>/ {\
     print;\
     print "";\
     print "  implicit lazy val arbitrary$className$: Arbitrary[$className$] =";\

--- a/.g8/datePage/app/controllers/$className$Controller.scala
+++ b/.g8/datePage/app/controllers/$className$Controller.scala
@@ -6,6 +6,7 @@ import javax.inject.Inject
 import models.{Mode, LocalReferenceNumber}
 import pages.$className$Page
 import navigation.Navigator
+import navigation.annotations.$navRoute$
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -19,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class $className$Controller @Inject()(
                                        override val messagesApi: MessagesApi,
                                        sessionRepository: SessionRepository,
-                                       navigator: Navigator,
+                                       @$navRoute$ navigator: Navigator,
                                        identify: IdentifierAction,
                                        getData: DataRetrievalActionProvider,
                                        requireData: DataRequiredAction,
@@ -28,7 +29,8 @@ class $className$Controller @Inject()(
                                        renderer: Renderer
 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with NunjucksSupport {
 
-  val form = formProvider()
+  private val form = formProvider()
+  private val template = "$className;format="decap"$.njk"
 
   def onPageLoad(lrn: LocalReferenceNumber, mode: Mode): Action[AnyContent] = (identify andThen getData(lrn) andThen requireData).async {
     implicit request =>
@@ -47,7 +49,7 @@ class $className$Controller @Inject()(
         "date" -> viewModel
       )
 
-      renderer.render("$className;format="decap"$.njk", json).map(Ok(_))
+      renderer.render(template, json).map(Ok(_))
   }
 
   def onSubmit(lrn: LocalReferenceNumber, mode: Mode): Action[AnyContent] = (identify andThen getData(lrn) andThen requireData).async {
@@ -65,7 +67,7 @@ class $className$Controller @Inject()(
             "date" -> viewModel
           )
 
-          renderer.render("$className;format="decap"$.njk", json).map(BadRequest(_))
+          renderer.render(template, json).map(BadRequest(_))
         },
         value =>
           for {

--- a/.g8/datePage/default.properties
+++ b/.g8/datePage/default.properties
@@ -1,2 +1,3 @@
 description = Generates a controller and view for a page with a single date
 className = MyNewDatePage
+navRoute = PreTaskListDetails

--- a/.g8/datePage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/datePage/generated-test/controllers/$className$ControllerSpec.scala
@@ -6,7 +6,8 @@ import base.SpecBase
 import forms.$className$FormProvider
 import matchers.JsonMatchers
 import models.{NormalMode, UserAnswers}
-import navigation.FakeNavigator
+import navigation.{FakeNavigator, Navigator}
+import navigation.annotations.$navRoute$
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
@@ -25,8 +26,9 @@ import scala.concurrent.Future
 
 class $className$ControllerSpec extends SpecBase with MockitoSugar with NunjucksSupport with JsonMatchers {
 
-  val formProvider = new $className$FormProvider()
+  private val formProvider = new $className$FormProvider()
   private def form = formProvider()
+  private val template = "$className;format="decap"$.njk"
 
   def onwardRoute = Call("GET", "/foo")
 
@@ -71,8 +73,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "date" -> viewModel
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }
@@ -110,8 +114,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "date" -> viewModel
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }
@@ -125,7 +131,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind(classOf[Navigator]).qualifiedWith(classOf[$navRoute$]).toInstance(new FakeNavigator(onwardRoute)),
             bind[SessionRepository].toInstance(mockSessionRepository)
           )
           .build()
@@ -165,8 +171,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "date" -> viewModel
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }

--- a/.g8/datePage/migrations/$className__snake$.sh
+++ b/.g8/datePage/migrations/$className__snake$.sh
@@ -24,7 +24,7 @@ echo "$className;format="decap"$.error.required = The $className;format="decap"$
 echo "$className;format="decap"$.error.invalid = Enter a real $className$" >> ../conf/messages.en
 
 echo "Adding to UserAnswersEntryGenerators"
-awk '/trait UserAnswersEntryGenerators/ {\
+awk '/self: Generators =>/ {\
     print;\
     print "";\
     print "  implicit lazy val arbitrary$className$UserAnswersEntry: Arbitrary[($className$Page.type, JsValue)] =";\

--- a/.g8/intPage/app/controllers/$className$Controller.scala
+++ b/.g8/intPage/app/controllers/$className$Controller.scala
@@ -5,6 +5,8 @@ import forms.$className$FormProvider
 import javax.inject.Inject
 import pages.$className$Page
 import models.{Mode, LocalReferenceNumber}
+import navigation.Navigator
+import navigation.annotations.$navRoute$
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -18,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class $className$Controller @Inject()(
                                        override val messagesApi: MessagesApi,
                                        sessionRepository: SessionRepository,
-                                       navigator: Navigator,
+                                       @$navRoute$ navigator: Navigator,
                                        identify: IdentifierAction,
                                        getData: DataRetrievalActionProvider,
                                        requireData: DataRequiredAction,
@@ -28,6 +30,7 @@ class $className$Controller @Inject()(
 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with NunjucksSupport {
 
   private val form = formProvider()
+  private val template = "$className;format="decap"$.njk"
 
   def onPageLoad(lrn: LocalReferenceNumber, mode: Mode): Action[AnyContent] = (identify andThen getData(lrn) andThen requireData).async {
     implicit request =>
@@ -43,7 +46,7 @@ class $className$Controller @Inject()(
         "mode" -> mode
       )
 
-      renderer.render("$className;format="decap"$.njk", json).map(Ok(_))
+      renderer.render(template, json).map(Ok(_))
   }
 
   def onSubmit(lrn: LocalReferenceNumber, mode: Mode): Action[AnyContent] = (identify andThen getData(lrn) andThen requireData).async {
@@ -58,7 +61,7 @@ class $className$Controller @Inject()(
             "mode" -> mode
           )
 
-          renderer.render("$className;format="decap"$.njk", json).map(BadRequest(_))
+          renderer.render(template, json).map(BadRequest(_))
         },
         value =>
           for {

--- a/.g8/intPage/default.properties
+++ b/.g8/intPage/default.properties
@@ -1,4 +1,5 @@
 description = Generates a controller and view for a page with a single integer question
 className = MyNewPage
+navRoute = PreTaskListDetails
 minimum = 0
 maximum = Int.MaxValue

--- a/.g8/intPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/intPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -4,7 +4,8 @@ import base.SpecBase
 import forms.$className$FormProvider
 import matchers.JsonMatchers
 import models.{NormalMode, UserAnswers}
-import navigation.FakeNavigator
+import navigation.{FakeNavigator, Navigator}
+import navigation.annotations.$navRoute$
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
@@ -23,8 +24,9 @@ import scala.concurrent.Future
 
 class $className$ControllerSpec extends SpecBase with MockitoSugar with NunjucksSupport with JsonMatchers {
 
-  val formProvider = new $className$FormProvider()
-  val form = formProvider()
+  private val formProvider = new $className$FormProvider()
+  private val form = formProvider()
+  private val template = "$className;format="decap"$.njk"
 
   def onwardRoute = Call("GET", "/foo")
 
@@ -56,8 +58,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "mode" -> NormalMode
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }
@@ -87,8 +91,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "mode" -> NormalMode
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }
@@ -102,7 +108,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind(classOf[Navigator]).qualifiedWith(classOf[$navRoute$]).toInstance(new FakeNavigator(onwardRoute)),
             bind[SessionRepository].toInstance(mockSessionRepository)
           )
           .build()
@@ -143,8 +149,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "mode" -> NormalMode
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }

--- a/.g8/intPage/migrations/$className__snake$.sh
+++ b/.g8/intPage/migrations/$className__snake$.sh
@@ -23,7 +23,7 @@ echo "$className;format="decap"$.error.wholeNumber = Enter your $className;forma
 echo "$className;format="decap"$.error.outOfRange = $className$ must be between {0} and {1}" >> ../conf/messages.en
 
 echo "Adding to UserAnswersEntryGenerators"
-awk '/trait UserAnswersEntryGenerators/ {\
+awk '/self: Generators =>/ {\
     print;\
     print "";\
     print "  implicit lazy val arbitrary$className$UserAnswersEntry: Arbitrary[($className$Page.type, JsValue)] =";\

--- a/.g8/optionsPage/app/controllers/$className$Controller.scala
+++ b/.g8/optionsPage/app/controllers/$className$Controller.scala
@@ -4,6 +4,8 @@ import controllers.actions._
 import forms.$className$FormProvider
 import javax.inject.Inject
 import models.{Mode, LocalReferenceNumber, $className$}
+import navigation.Navigator
+import navigation.annotations.$navRoute$
 import pages.$className$Page
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json.Json
@@ -18,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class $className$Controller @Inject()(
                                        override val messagesApi: MessagesApi,
                                        sessionRepository: SessionRepository,
-                                       navigator: Navigator,
+                                       @$navRoute$ navigator: Navigator,
                                        identify: IdentifierAction,
                                        getData: DataRetrievalActionProvider,
                                        requireData: DataRequiredAction,
@@ -28,6 +30,7 @@ class $className$Controller @Inject()(
 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with NunjucksSupport {
 
   private val form = formProvider()
+  private val template = "$className;format="decap"$.njk"
 
   def onPageLoad(lrn: LocalReferenceNumber, mode: Mode): Action[AnyContent] = (identify andThen getData(lrn) andThen requireData).async {
     implicit request =>
@@ -44,7 +47,7 @@ class $className$Controller @Inject()(
         "radios"  -> $className$.radios(preparedForm)
       )
 
-      renderer.render("$className;format="decap"$.njk", json).map(Ok(_))
+      renderer.render(template, json).map(Ok(_))
   }
 
   def onSubmit(lrn: LocalReferenceNumber, mode: Mode): Action[AnyContent] = (identify andThen getData(lrn) andThen requireData).async {
@@ -60,7 +63,7 @@ class $className$Controller @Inject()(
             "radios" -> $className$.radios(formWithErrors)
           )
 
-          renderer.render("$className;format="decap"$.njk", json).map(BadRequest(_))
+          renderer.render(template, json).map(BadRequest(_))
         },
         value =>
           for {

--- a/.g8/optionsPage/default.properties
+++ b/.g8/optionsPage/default.properties
@@ -1,5 +1,6 @@
 description = Generates a controller and view for a page with a set of radio buttons
 className = MyNewPage
+navRoute = PreTaskListDetails
 title = $className;format="decap"$
 option1key = option1
 option1msg = Option 1

--- a/.g8/optionsPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/optionsPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -4,7 +4,8 @@ import base.SpecBase
 import forms.$className$FormProvider
 import matchers.JsonMatchers
 import models.{NormalMode, $className$, UserAnswers}
-import navigation.FakeNavigator
+import navigation.{FakeNavigator, Navigator}
+import navigation.annotations.$navRoute$
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
@@ -27,8 +28,9 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
 
   lazy val $className;format="decap"$Route = routes.$className$Controller.onPageLoad(lrn, NormalMode).url
 
-  val formProvider = new $className$FormProvider()
-  val form = formProvider()
+  private val formProvider = new $className$FormProvider()
+  private val form = formProvider()
+  private val template = "$className;format="decap"$.njk"
 
   "$className$ Controller" - {
 
@@ -55,8 +57,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "radios" -> $className$.radios(form)
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }
@@ -87,8 +91,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "radios" -> $className$.radios(filledForm)
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }
@@ -102,7 +108,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind(classOf[Navigator]).qualifiedWith(classOf[$navRoute$]).toInstance(new FakeNavigator(onwardRoute)),
             bind[SessionRepository].toInstance(mockSessionRepository)
           )
           .build()
@@ -144,8 +150,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "radios" -> $className$.radios(boundForm)
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }

--- a/.g8/questionPage/app/controllers/$className$Controller.scala
+++ b/.g8/questionPage/app/controllers/$className$Controller.scala
@@ -4,6 +4,8 @@ import controllers.actions._
 import forms.$className$FormProvider
 import javax.inject.Inject
 import models.{Mode, LocalReferenceNumber}
+import navigation.Navigator
+import navigation.annotations.$navRoute$
 import pages.$className$Page
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json.Json
@@ -18,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class $className$Controller @Inject()(
                                        override val messagesApi: MessagesApi,
                                        sessionRepository: SessionRepository,
-                                       navigator: Navigator,
+                                       @$navRoute$ navigator: Navigator,
                                        identify: IdentifierAction,
                                        getData: DataRetrievalActionProvider,
                                        requireData: DataRequiredAction,
@@ -28,6 +30,7 @@ class $className$Controller @Inject()(
 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with NunjucksSupport {
 
   private val form = formProvider()
+  private val template = "$className;format="decap"$.njk"
 
   def onPageLoad(lrn: LocalReferenceNumber, mode: Mode): Action[AnyContent] = (identify andThen getData(lrn) andThen requireData).async {
     implicit request =>
@@ -43,7 +46,7 @@ class $className$Controller @Inject()(
         "mode" -> mode
       )
 
-      renderer.render("$className;format="decap"$.njk", json).map(Ok(_))
+      renderer.render(template, json).map(Ok(_))
   }
 
   def onSubmit(lrn: LocalReferenceNumber, mode: Mode): Action[AnyContent] = (identify andThen getData(lrn) andThen requireData).async {
@@ -58,7 +61,7 @@ class $className$Controller @Inject()(
             "mode" -> mode
           )
     
-          renderer.render("$className;format="decap"$.njk", json).map(BadRequest(_))
+          renderer.render(template, json).map(BadRequest(_))
         },
         value =>
           for {

--- a/.g8/questionPage/default.properties
+++ b/.g8/questionPage/default.properties
@@ -1,5 +1,6 @@
 description = Generates a controller and view for a page with multiple questions
 className = MyNewPage
+navRoute = PreTaskListDetails
 field1Name = field1
 field1MaxLength = 100
 field2Name = field2

--- a/.g8/questionPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/questionPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -4,7 +4,8 @@ import base.SpecBase
 import forms.$className$FormProvider
 import matchers.JsonMatchers
 import models.{NormalMode, $className$, UserAnswers}
-import navigation.FakeNavigator
+import navigation.{FakeNavigator, Navigator}
+import navigation.annotations.$navRoute$
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
@@ -25,8 +26,9 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
 
   def onwardRoute = Call("GET", "/foo")
 
-  val formProvider = new $className$FormProvider()
-  val form = formProvider()
+  private val formProvider = new $className$FormProvider()
+  private val form = formProvider()
+  private val template = "$className;format="decap"$.njk"
 
   lazy val $className;format="decap"$Route = routes.$className$Controller.onPageLoad(lrn, NormalMode).url
 
@@ -65,8 +67,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "mode" -> NormalMode
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }
@@ -100,8 +104,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "mode" -> NormalMode
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }
@@ -115,7 +121,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind(classOf[Navigator]).qualifiedWith(classOf[$navRoute$]).toInstance(new FakeNavigator(onwardRoute)),
             bind[SessionRepository].toInstance(mockSessionRepository)
           )
           .build()
@@ -157,8 +163,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "mode" -> NormalMode
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
       
        application.stop()
     }

--- a/.g8/questionPage/migrations/$className__snake$.sh
+++ b/.g8/questionPage/migrations/$className__snake$.sh
@@ -25,11 +25,8 @@ echo "$className;format="decap"$.error.$field1Name$.length = $field1Name$ must b
 echo "$className;format="decap"$.error.$field2Name$.length = $field2Name$ must be $field2MaxLength$ characters or less" >> ../conf/messages.en
 
 echo "Adding to UserAnswersEntryGenerators"
-awk '/trait UserAnswersEntryGenerators/ {\
+awk '/self: Generators =>/ {\
     print;\
-    print "";\
-    print "self: Generators =>";\
-      print "";\
     print "  implicit lazy val arbitrary$className$UserAnswersEntry: Arbitrary[($className$Page.type, JsValue)] =";\
     print "    Arbitrary {";\
     print "      for {";\
@@ -48,7 +45,7 @@ awk '/trait PageGenerators/ {\
     next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
 
 echo "Adding to ModelGenerators"
-awk '/trait ModelGenerators/ {\
+awk '/self: Generators =>/ {\
     print;\
     print "";\
     print "  implicit lazy val arbitrary$className$: Arbitrary[$className$] =";\

--- a/.g8/stringPage/app/controllers/$className$Controller.scala
+++ b/.g8/stringPage/app/controllers/$className$Controller.scala
@@ -4,6 +4,8 @@ import controllers.actions._
 import forms.$className$FormProvider
 import javax.inject.Inject
 import models.{Mode, LocalReferenceNumber}
+import navigation.Navigator
+import navigation.annotations.$navRoute$
 import pages.$className$Page
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json.Json
@@ -18,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class $className$Controller @Inject()(
                                        override val messagesApi: MessagesApi,
                                        sessionRepository: SessionRepository,
-                                       navigator: Navigator,
+                                       @$navRoute$ navigator: Navigator,
                                        identify: IdentifierAction,
                                        getData: DataRetrievalActionProvider,
                                        requireData: DataRequiredAction,
@@ -28,6 +30,7 @@ class $className$Controller @Inject()(
 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with NunjucksSupport {
 
   private val form = formProvider()
+  private val template = "$className;format="decap"$.njk"
 
   def onPageLoad(lrn: LocalReferenceNumber, mode: Mode): Action[AnyContent] = (identify andThen getData(lrn) andThen requireData).async {
     implicit request =>
@@ -43,7 +46,7 @@ class $className$Controller @Inject()(
         "mode" -> mode
       )
 
-      renderer.render("$className;format="decap"$.njk", json).map(Ok(_))
+      renderer.render(template, json).map(Ok(_))
   }
 
   def onSubmit(lrn: LocalReferenceNumber, mode: Mode): Action[AnyContent] = (identify andThen getData(lrn) andThen requireData).async {
@@ -58,7 +61,7 @@ class $className$Controller @Inject()(
             "mode" -> mode
           )
 
-          renderer.render("$className;format="decap"$.njk", json).map(BadRequest(_))
+          renderer.render(template, json).map(BadRequest(_))
         },
         value =>
           for {

--- a/.g8/stringPage/default.properties
+++ b/.g8/stringPage/default.properties
@@ -1,3 +1,4 @@
 description = Generates a controller and view for a page with a single string question
 className = MyNewPage
+navRoute = PreTaskListDetails
 maxLength = 100

--- a/.g8/stringPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/stringPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -1,10 +1,11 @@
 package controllers
 
 import base.SpecBase
-import forms.$className$FormProvider
 import matchers.JsonMatchers
+import forms.$className$FormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.FakeNavigator
+import navigation.{FakeNavigator, Navigator}
+import navigation.annotations.$navRoute$
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
@@ -25,8 +26,9 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
 
   def onwardRoute = Call("GET", "/foo")
 
-  val formProvider = new $className$FormProvider()
-  val form = formProvider()
+  private val formProvider = new $className$FormProvider()
+  private val form = formProvider()
+  private val template = "$className;format="decap"$.njk"
 
   lazy val $className;format="decap"$Route = routes.$className$Controller.onPageLoad(lrn, NormalMode).url
 
@@ -54,8 +56,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "lrn"    -> lrn
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }
@@ -85,8 +89,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "mode" -> NormalMode
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }
@@ -100,7 +106,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind(classOf[Navigator]).qualifiedWith(classOf[$navRoute$]).toInstance(new FakeNavigator(onwardRoute)),
             bind[SessionRepository].toInstance(mockSessionRepository)
           )
           .build()
@@ -140,7 +146,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "mode" -> NormalMode
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
+      templateCaptor.getValue mustEqual template
       jsonCaptor.getValue must containJson(expectedJson)
 
       application.stop()

--- a/.g8/stringPage/migrations/$className__snake$.sh
+++ b/.g8/stringPage/migrations/$className__snake$.sh
@@ -21,7 +21,7 @@ echo "$className;format="decap"$.error.required = Enter $className;format="decap
 echo "$className;format="decap"$.error.length = $className$ must be $maxLength$ characters or less" >> ../conf/messages.en
 
 echo "Adding to UserAnswersEntryGenerators"
-awk '/trait UserAnswersEntryGenerators/ {\
+awk '/self: Generators =>/ {\
     print;\
     print "";\
     print "  implicit lazy val arbitrary$className$UserAnswersEntry: Arbitrary[($className$Page.type, JsValue)] =";\

--- a/.g8/yesNoPage/app/controllers/$className$Controller.scala
+++ b/.g8/yesNoPage/app/controllers/$className$Controller.scala
@@ -4,6 +4,8 @@ import controllers.actions._
 import forms.$className$FormProvider
 import javax.inject.Inject
 import models.{Mode, LocalReferenceNumber}
+import navigation.Navigator
+import navigation.annotations.$navRoute$
 import pages.$className$Page
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json.Json
@@ -18,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class $className;format="cap"$Controller @Inject()(
     override val messagesApi: MessagesApi,
     sessionRepository: SessionRepository,
-    navigator: Navigator,
+    @$navRoute$ navigator: Navigator,
     identify: IdentifierAction,
     getData: DataRetrievalActionProvider,
     requireData: DataRequiredAction,
@@ -28,6 +30,7 @@ class $className;format="cap"$Controller @Inject()(
 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with NunjucksSupport {
 
   private val form = formProvider()
+  private val template = "$className;format="decap"$.njk"
 
   def onPageLoad(lrn: LocalReferenceNumber, mode: Mode): Action[AnyContent] = (identify andThen getData(lrn) andThen requireData).async {
     implicit request =>
@@ -44,7 +47,7 @@ class $className;format="cap"$Controller @Inject()(
         "radios" -> Radios.yesNo(preparedForm("value"))
       )
 
-      renderer.render("$className;format="decap"$.njk", json).map(Ok(_))
+      renderer.render(template, json).map(Ok(_))
   }
 
   def onSubmit(lrn: LocalReferenceNumber, mode: Mode): Action[AnyContent] = (identify andThen getData(lrn) andThen requireData).async {
@@ -60,7 +63,7 @@ class $className;format="cap"$Controller @Inject()(
             "radios" -> Radios.yesNo(formWithErrors("value"))
           )
     
-          renderer.render("$className;format="decap"$.njk", json).map(BadRequest(_))
+          renderer.render(template, json).map(BadRequest(_))
         },
         value =>
           for {

--- a/.g8/yesNoPage/default.properties
+++ b/.g8/yesNoPage/default.properties
@@ -1,2 +1,4 @@
 description = Generates a controller and view for a page with a single yes / no question
 className = MyNewPage
+navRoute = PreTaskListDetails
+

--- a/.g8/yesNoPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/yesNoPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -4,7 +4,8 @@ import base.SpecBase
 import forms.$className$FormProvider
 import matchers.JsonMatchers
 import models.{NormalMode, UserAnswers}
-import navigation.FakeNavigator
+import navigation.{FakeNavigator, Navigator}
+import navigation.annotations.$navRoute$
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
@@ -25,8 +26,9 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
 
   def onwardRoute = Call("GET", "/foo")
 
-  val formProvider = new $className$FormProvider()
-  val form = formProvider()
+  private val formProvider = new $className$FormProvider()
+  private val form = formProvider()
+  private val template = "$className;format="decap"$.njk"
 
   lazy val $className;format="decap"$Route = routes.$className$Controller.onPageLoad(lrn, NormalMode).url
 
@@ -55,8 +57,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "radios" -> Radios.yesNo(form("value"))
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }
@@ -87,8 +91,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "radios" -> Radios.yesNo(filledForm("value"))
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }
@@ -102,7 +108,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind(classOf[Navigator]).qualifiedWith(classOf[$navRoute$]).toInstance(new FakeNavigator(onwardRoute)),
             bind[SessionRepository].toInstance(mockSessionRepository)
           )
           .build()
@@ -144,8 +150,10 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar with Nunjucks
         "radios" -> Radios.yesNo(boundForm("value"))
       )
 
-      templateCaptor.getValue mustEqual "$className;format="decap"$.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
 
       application.stop()
     }

--- a/.g8/yesNoPage/migrations/$className__snake$.sh
+++ b/.g8/yesNoPage/migrations/$className__snake$.sh
@@ -20,7 +20,7 @@ echo "$className;format="decap"$.checkYourAnswersLabel = $className;format="deca
 echo "$className;format="decap"$.error.required = Select yes if $className;format="decap"$" >> ../conf/messages.en
 
 echo "Adding to UserAnswersEntryGenerators"
-awk '/trait UserAnswersEntryGenerators/ {\
+awk '/self: Generators =>/ {\
     print;\
     print "";\
     print "  implicit lazy val arbitrary$className$UserAnswersEntry: Arbitrary[($className$Page.type, JsValue)] =";\


### PR DESCRIPTION
- Enabled navigator to be selected on generation, default to the base option.
- Fixed migration to insert at correct point
- Fixed tests to allow for this.
- Updated test to confirm Json is correct so not to miss added items.

Note: Some CYA, CYAHelpers will fail as the controller is missing imports as only used on these pages 