### PR TITLE
CTCTRADERS-2455 Change country query that allows for filtering of countries with customs offices

### DIFF
--- a/app/connectors/ReferenceDataConnector.scala
+++ b/app/connectors/ReferenceDataConnector.scala
@@ -51,7 +51,7 @@ class ReferenceDataConnector @Inject() (config: FrontendAppConfig, http: HttpCli
   def getCountriesWithCustomsOffices(excludeCountries: Seq[CountryCode])(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[CountryList] = {
     val serviceUrl = s"${config.referenceDataUrl}/countries"
 
-    val customsOfficeQuery = Seq("customsOffice" -> "true")
+    val customsOfficeQuery = Seq("customsOfficeRole" -> "ANY")
 
     val excludeCountriesQuery = excludeCountries
       .map(_.code)

--- a/app/connectors/ReferenceDataConnector.scala
+++ b/app/connectors/ReferenceDataConnector.scala
@@ -55,7 +55,7 @@ class ReferenceDataConnector @Inject() (config: FrontendAppConfig, http: HttpCli
 
     val excludeCountriesQuery = excludeCountries
       .map(_.code)
-      .map("excludeCountries" -> _)
+      .map("exclude" -> _)
 
     val queryParameters: Seq[(String, String)] = customsOfficeQuery ++ excludeCountriesQuery
 

--- a/app/connectors/ReferenceDataConnector.scala
+++ b/app/connectors/ReferenceDataConnector.scala
@@ -48,6 +48,20 @@ class ReferenceDataConnector @Inject() (config: FrontendAppConfig, http: HttpCli
     http.GET[Seq[Country]](serviceUrl).map(CountryList(_))
   }
 
+  def getCountriesWithCustomsOffices(excludeCountries: Seq[CountryCode])(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[CountryList] = {
+    val serviceUrl = s"${config.referenceDataUrl}/countries"
+
+    val customsOfficeQuery = Seq("customsOffice" -> "true")
+
+    val excludeCountriesQuery = excludeCountries
+      .map(_.code)
+      .map("excludeCountries" -> _)
+
+    val queryParameters: Seq[(String, String)] = customsOfficeQuery ++ excludeCountriesQuery
+
+    http.GET[Seq[Country]](serviceUrl, queryParameters).map(CountryList(_))
+  }
+
   def getTransitCountryList(excludeCountries: Seq[CountryCode] = Nil)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[CountryList] = {
     val serviceUrl = s"${config.referenceDataUrl}/transit-countries"
 

--- a/app/controllers/routeDetails/MovementDestinationCountryController.scala
+++ b/app/controllers/routeDetails/MovementDestinationCountryController.scala
@@ -22,7 +22,7 @@ import connectors.ReferenceDataConnector
 import controllers.actions._
 import forms.MovementDestinationCountryFormProvider
 import logging.Logging
-import models.reference.{Country, CountryCode}
+import models.reference.Country
 import models.{LocalReferenceNumber, Mode}
 import navigation.Navigator
 import navigation.annotations.RouteDetails
@@ -63,7 +63,7 @@ class MovementDestinationCountryController @Inject() (
       (
         for {
           excludedCountries <- OptionT.fromOption[Future](routeDetailsExcludedCountries(request.userAnswers))
-          countries         <- OptionT.liftF(referenceDataConnector.getTransitCountryList(excludedCountries))
+          countries         <- OptionT.liftF(referenceDataConnector.getCountriesWithCustomsOffices(excludedCountries))
           preparedForm = request.userAnswers
             .get(MovementDestinationCountryPage)
             .flatMap(countries.getCountry)
@@ -82,7 +82,7 @@ class MovementDestinationCountryController @Inject() (
       (
         for {
           excludedCountries <- OptionT.fromOption[Future](routeDetailsExcludedCountries(request.userAnswers))
-          countries         <- OptionT.liftF(referenceDataConnector.getTransitCountryList(excludedCountries))
+          countries         <- OptionT.liftF(referenceDataConnector.getCountriesWithCustomsOffices(excludedCountries))
           page <- OptionT.liftF(
             formProvider(countries)
               .bindFromRequest()

--- a/app/controllers/routeDetails/OfficeOfTransitCountryController.scala
+++ b/app/controllers/routeDetails/OfficeOfTransitCountryController.scala
@@ -65,7 +65,7 @@ class OfficeOfTransitCountryController @Inject() (
         (
           for {
             excludedCountries  <- OptionT.fromOption[Future](routeDetailsExcludedCountries(request.userAnswers))
-            transitCountryList <- OptionT.liftF(referenceDataConnector.getTransitCountryList(excludedCountries))
+            transitCountryList <- OptionT.liftF(referenceDataConnector.getCountriesWithCustomsOffices(excludedCountries))
             form = formProvider(transitCountryList)
             preparedForm = request.userAnswers
               .get(OfficeOfTransitCountryPage(index))
@@ -85,7 +85,7 @@ class OfficeOfTransitCountryController @Inject() (
       (
         for {
           excludedCountries  <- OptionT.fromOption[Future](routeDetailsExcludedCountries(request.userAnswers))
-          transitCountryList <- OptionT.liftF(referenceDataConnector.getTransitCountryList(excludedCountries))
+          transitCountryList <- OptionT.liftF(referenceDataConnector.getCountriesWithCustomsOffices(excludedCountries))
           page <- OptionT.liftF(
             formProvider(transitCountryList)
               .bindFromRequest()

--- a/test/connectors/ReferenceDataConnectorSpec.scala
+++ b/test/connectors/ReferenceDataConnectorSpec.scala
@@ -359,7 +359,7 @@ class ReferenceDataConnectorSpec extends SpecBase with WireMockServerHandler wit
 
       "when there are no excluded coutries, must return Seq of Country when successful" in {
         server.stubFor(
-          get(urlEqualTo(s"/$startUrl/countries?customsOffice=true"))
+          get(urlEqualTo(s"/$startUrl/countries?customsOfficeRole=ANY"))
             .willReturn(okJson(countryListResponseJson))
         )
 
@@ -375,7 +375,7 @@ class ReferenceDataConnectorSpec extends SpecBase with WireMockServerHandler wit
 
       "when there are excluded coutries, then the excluded coutries must be sent as a query paramter and the request returns a Seq of Country when successful" in {
         server.stubFor(
-          get(urlEqualTo(s"/$startUrl/countries?customsOffice=true&exclude=JE&exclude=AB"))
+          get(urlEqualTo(s"/$startUrl/countries?customsOfficeRole=ANY&exclude=JE&exclude=AB"))
             .willReturn(okJson(countryListResponseJson))
         )
 
@@ -390,7 +390,7 @@ class ReferenceDataConnectorSpec extends SpecBase with WireMockServerHandler wit
       }
 
       "must return an exception when an error response is returned" in {
-        checkErrorResponse(s"/$startUrl/countries?customsOffice=true", connector.getCountriesWithCustomsOffices(Nil))
+        checkErrorResponse(s"/$startUrl/countries?customsOfficeRole=ANY", connector.getCountriesWithCustomsOffices(Nil))
       }
     }
 

--- a/test/connectors/ReferenceDataConnectorSpec.scala
+++ b/test/connectors/ReferenceDataConnectorSpec.scala
@@ -17,7 +17,10 @@
 package connectors
 
 import base.SpecBase
-import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, equalTo, get, okJson, urlEqualTo}
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.okJson
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import helper.WireMockServerHandler
 import models.reference._
 import models.{
@@ -349,6 +352,45 @@ class ReferenceDataConnectorSpec extends SpecBase with WireMockServerHandler wit
       "must return an exception when an error response is returned" in {
 
         checkErrorResponse(s"/$startUrl/countries-full-list", connector.getCountryList)
+      }
+    }
+
+    "getCountriesWithCustomsOffices" - {
+
+      "when there are no excluded coutries, must return Seq of Country when successful" in {
+        server.stubFor(
+          get(urlEqualTo(s"/$startUrl/countries?customsOffice=true"))
+            .willReturn(okJson(countryListResponseJson))
+        )
+
+        val expectedResult: CountryList = CountryList(
+          Seq(
+            Country(CountryCode("GB"), "United Kingdom"),
+            Country(CountryCode("AD"), "Andorra")
+          )
+        )
+
+        connector.getCountriesWithCustomsOffices(Nil).futureValue mustEqual expectedResult
+      }
+
+      "when there are excluded coutries, then the excluded coutries must be sent as a query paramter and the request returns a Seq of Country when successful" in {
+        server.stubFor(
+          get(urlEqualTo(s"/$startUrl/countries?customsOffice=true&excludeCountries=JE&excludeCountries=AB"))
+            .willReturn(okJson(countryListResponseJson))
+        )
+
+        val expectedResult: CountryList = CountryList(
+          Seq(
+            Country(CountryCode("GB"), "United Kingdom"),
+            Country(CountryCode("AD"), "Andorra")
+          )
+        )
+
+        connector.getCountriesWithCustomsOffices(Seq(CountryCode("JE"), CountryCode("AB"))).futureValue mustEqual expectedResult
+      }
+
+      "must return an exception when an error response is returned" in {
+        checkErrorResponse(s"/$startUrl/countries-full-list", connector.getCountriesWithCustomsOffices(Nil))
       }
     }
 

--- a/test/connectors/ReferenceDataConnectorSpec.scala
+++ b/test/connectors/ReferenceDataConnectorSpec.scala
@@ -375,7 +375,7 @@ class ReferenceDataConnectorSpec extends SpecBase with WireMockServerHandler wit
 
       "when there are excluded coutries, then the excluded coutries must be sent as a query paramter and the request returns a Seq of Country when successful" in {
         server.stubFor(
-          get(urlEqualTo(s"/$startUrl/countries?customsOffice=true&excludeCountries=JE&excludeCountries=AB"))
+          get(urlEqualTo(s"/$startUrl/countries?customsOffice=true&exclude=JE&exclude=AB"))
             .willReturn(okJson(countryListResponseJson))
         )
 
@@ -390,7 +390,7 @@ class ReferenceDataConnectorSpec extends SpecBase with WireMockServerHandler wit
       }
 
       "must return an exception when an error response is returned" in {
-        checkErrorResponse(s"/$startUrl/countries-full-list", connector.getCountriesWithCustomsOffices(Nil))
+        checkErrorResponse(s"/$startUrl/countries?customsOffice=true", connector.getCountriesWithCustomsOffices(Nil))
       }
     }
 

--- a/test/controllers/routeDetails/MovementDestinationCountryControllerSpec.scala
+++ b/test/controllers/routeDetails/MovementDestinationCountryControllerSpec.scala
@@ -76,7 +76,7 @@ class MovementDestinationCountryControllerSpec extends SpecBase with MockNunjuck
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      when(mockReferenceDataConnector.getTransitCountryList(any())(any(), any())).thenReturn(Future.successful(countries))
+      when(mockReferenceDataConnector.getCountriesWithCustomsOffices(any())(any(), any())).thenReturn(Future.successful(countries))
 
       dataRetrievalWithData(userAnswers)
 
@@ -90,7 +90,7 @@ class MovementDestinationCountryControllerSpec extends SpecBase with MockNunjuck
 
       verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
       verify(mockReferenceDataConnector, times(1))
-        .getTransitCountryList(eqTo(alwaysExcludedTransitCountries))(any(), any())
+        .getCountriesWithCustomsOffices(eqTo(alwaysExcludedTransitCountries))(any(), any())
 
       val expectedJson = Json.obj(
         "form"        -> form,
@@ -115,7 +115,7 @@ class MovementDestinationCountryControllerSpec extends SpecBase with MockNunjuck
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      when(mockReferenceDataConnector.getTransitCountryList(any())(any(), any())).thenReturn(Future.successful(countries))
+      when(mockReferenceDataConnector.getCountriesWithCustomsOffices(any())(any(), any())).thenReturn(Future.successful(countries))
 
       dataRetrievalWithData(userAnswers)
 
@@ -129,7 +129,7 @@ class MovementDestinationCountryControllerSpec extends SpecBase with MockNunjuck
 
       verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
       verify(mockReferenceDataConnector, times(1))
-        .getTransitCountryList(eqTo(alwaysExcludedTransitCountries ++ gbExcludedCountries))(any(), any())
+        .getCountriesWithCustomsOffices(eqTo(alwaysExcludedTransitCountries ++ gbExcludedCountries))(any(), any())
 
       val expectedJson = Json.obj(
         "form"        -> form,
@@ -155,7 +155,7 @@ class MovementDestinationCountryControllerSpec extends SpecBase with MockNunjuck
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      when(mockReferenceDataConnector.getTransitCountryList(any())(any(), any())).thenReturn(Future.successful(countries))
+      when(mockReferenceDataConnector.getCountriesWithCustomsOffices(any())(any(), any())).thenReturn(Future.successful(countries))
 
       dataRetrievalWithData(userAnswers)
 
@@ -193,7 +193,7 @@ class MovementDestinationCountryControllerSpec extends SpecBase with MockNunjuck
 
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
 
-      when(mockReferenceDataConnector.getTransitCountryList(any())(any(), any())).thenReturn(Future.successful(countries))
+      when(mockReferenceDataConnector.getCountriesWithCustomsOffices(any())(any(), any())).thenReturn(Future.successful(countries))
 
       dataRetrievalWithData(userAnswers)
 
@@ -216,7 +216,7 @@ class MovementDestinationCountryControllerSpec extends SpecBase with MockNunjuck
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      when(mockReferenceDataConnector.getTransitCountryList(eqTo(Seq(CountryCode("JE"))))(any(), any())).thenReturn(Future.successful(countries))
+      when(mockReferenceDataConnector.getCountriesWithCustomsOffices(eqTo(Seq(CountryCode("JE"))))(any(), any())).thenReturn(Future.successful(countries))
 
       dataRetrievalWithData(userAnswers)
 

--- a/test/controllers/routeDetails/OfficeOfTransitCountryControllerSpec.scala
+++ b/test/controllers/routeDetails/OfficeOfTransitCountryControllerSpec.scala
@@ -79,7 +79,7 @@ class OfficeOfTransitCountryControllerSpec
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      when(mockReferenceDataConnector.getTransitCountryList(any())(any(), any())).thenReturn(Future.successful(countries))
+      when(mockReferenceDataConnector.getCountriesWithCustomsOffices(any())(any(), any())).thenReturn(Future.successful(countries))
 
       val userAnswers = emptyUserAnswers.unsafeSetVal(OfficeOfDeparturePage)(CustomsOffice("id", "name", CountryCode("XI"), None))
 
@@ -95,7 +95,7 @@ class OfficeOfTransitCountryControllerSpec
 
       verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
       verify(mockReferenceDataConnector, times(1))
-        .getTransitCountryList(eqTo(alwaysExcludedTransitCountries))(any(), any())
+        .getCountriesWithCustomsOffices(eqTo(alwaysExcludedTransitCountries))(any(), any())
 
       val expectedJson = Json.obj(
         "form"        -> form,
@@ -117,7 +117,7 @@ class OfficeOfTransitCountryControllerSpec
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      when(mockReferenceDataConnector.getTransitCountryList(any())(any(), any()))
+      when(mockReferenceDataConnector.getCountriesWithCustomsOffices(any())(any(), any()))
         .thenReturn(Future.successful(countries))
 
       val userAnswers = emptyUserAnswers.unsafeSetVal(OfficeOfDeparturePage)(CustomsOffice("id", "name", CountryCode("GB"), None))
@@ -134,7 +134,7 @@ class OfficeOfTransitCountryControllerSpec
 
       verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
       verify(mockReferenceDataConnector, times(1))
-        .getTransitCountryList(eqTo(alwaysExcludedTransitCountries ++ gbExcludedCountries))(any(), any())
+        .getCountriesWithCustomsOffices(eqTo(alwaysExcludedTransitCountries ++ gbExcludedCountries))(any(), any())
 
       val expectedJson = Json.obj(
         "form"        -> form,
@@ -156,7 +156,7 @@ class OfficeOfTransitCountryControllerSpec
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      when(mockReferenceDataConnector.getTransitCountryList(any())(any(), any())).thenReturn(Future.successful(countries))
+      when(mockReferenceDataConnector.getCountriesWithCustomsOffices(any())(any(), any())).thenReturn(Future.successful(countries))
 
       dataRetrievalWithData(emptyUserAnswers)
 
@@ -174,7 +174,7 @@ class OfficeOfTransitCountryControllerSpec
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      when(mockReferenceDataConnector.getTransitCountryList(any())(any(), any())).thenReturn(Future.successful(countries))
+      when(mockReferenceDataConnector.getCountriesWithCustomsOffices(any())(any(), any())).thenReturn(Future.successful(countries))
 
       val userAnswers = emptyUserAnswers
         .unsafeSetVal(OfficeOfDeparturePage)(CustomsOffice("id", "name", CountryCode("GB"), None))
@@ -213,7 +213,7 @@ class OfficeOfTransitCountryControllerSpec
 
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
 
-      when(mockReferenceDataConnector.getTransitCountryList(eqTo(Seq(CountryCode("JE"))))(any(), any())).thenReturn(Future.successful(countries))
+      when(mockReferenceDataConnector.getCountriesWithCustomsOffices(eqTo(Seq(CountryCode("JE"))))(any(), any())).thenReturn(Future.successful(countries))
 
       val userAnswers = emptyUserAnswers.unsafeSetVal(OfficeOfDeparturePage)(CustomsOffice("id", "name", CountryCode("GB"), None))
 
@@ -234,7 +234,7 @@ class OfficeOfTransitCountryControllerSpec
 
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
 
-      when(mockReferenceDataConnector.getTransitCountryList(eqTo(Seq(CountryCode("JE"))))(any(), any())).thenReturn(Future.successful(countries))
+      when(mockReferenceDataConnector.getCountriesWithCustomsOffices(eqTo(Seq(CountryCode("JE"))))(any(), any())).thenReturn(Future.successful(countries))
 
       dataRetrievalWithData(emptyUserAnswers)
 
@@ -254,7 +254,7 @@ class OfficeOfTransitCountryControllerSpec
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      when(mockReferenceDataConnector.getTransitCountryList(eqTo(Seq(CountryCode("JE"))))(any(), any())).thenReturn(Future.successful(countries))
+      when(mockReferenceDataConnector.getCountriesWithCustomsOffices(eqTo(Seq(CountryCode("JE"))))(any(), any())).thenReturn(Future.successful(countries))
 
       val userAnswers = emptyUserAnswers.unsafeSetVal(OfficeOfDeparturePage)(CustomsOffice("id", "name", CountryCode("GB"), None))
 


### PR DESCRIPTION
- CTCTRADERS-2455 Add connector method that gets countries that have customs offices
- CTCTRADERS-2455 Use Office of Destination country selector and filter for those with customs offices
- CTCTRADERS-2455 Use Office of Transit country selector and filter for those with customs offices
