### PR TITLE
CTCTRADERS-2836: Packages CYA

### DIFF
--- a/app/controllers/addItems/documents/DocumentCheckYourAnswersController.scala
+++ b/app/controllers/addItems/documents/DocumentCheckYourAnswersController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.addItems.packagesInformation
+package controllers.addItems.documents
 
 import controllers.actions._
 import models.{Index, LocalReferenceNumber, Mode, ValidateReaderLogger}
@@ -23,13 +23,13 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import renderer.Renderer
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import viewModels.PackagesCheckYourAnswersViewModel
+import viewModels.DocumentsCheckYourAnswersViewModel
 import viewModels.sections.Section
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 
-class PackageCheckYourAnswersController @Inject() (
+class DocumentCheckYourAnswersController @Inject() (
   override val messagesApi: MessagesApi,
   identify: IdentifierAction,
   getData: DataRetrievalActionProvider,
@@ -41,21 +41,21 @@ class PackageCheckYourAnswersController @Inject() (
     with ValidateReaderLogger
     with I18nSupport {
 
-  def onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, packageIndex: Index, mode: Mode): Action[AnyContent] =
+  def onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, documentIndex: Index, mode: Mode): Action[AnyContent] =
     (identify
       andThen getData(lrn)
       andThen requireData).async {
       implicit request =>
         val json = {
           val section: Section =
-            PackagesCheckYourAnswersViewModel(request.userAnswers, itemIndex, packageIndex, mode).section
+            DocumentsCheckYourAnswersViewModel(request.userAnswers, itemIndex, documentIndex, mode).section
 
           Json.obj(
             "section"     -> Json.toJson(section),
-            "nextPageUrl" -> routes.AddAnotherPackageController.onPageLoad(lrn, itemIndex, mode).url
+            "nextPageUrl" -> routes.AddAnotherDocumentController.onPageLoad(lrn, itemIndex, mode).url
           )
         }
 
-        renderer.render("addItems/packageCheckYourAnswers.njk", json).map(Ok(_))
+        renderer.render("addItems/documentCheckYourAnswers.njk", json).map(Ok(_))
     }
 }

--- a/app/controllers/addItems/packagesInformation/PackageCheckYourAnswersController.scala
+++ b/app/controllers/addItems/packagesInformation/PackageCheckYourAnswersController.scala
@@ -30,7 +30,7 @@ import viewModels.sections.Section
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 
-class PackagesCheckYourAnswersController @Inject() (
+class PackageCheckYourAnswersController @Inject() (
   override val messagesApi: MessagesApi,
   identify: IdentifierAction,
   getData: DataRetrievalActionProvider,
@@ -59,6 +59,6 @@ class PackagesCheckYourAnswersController @Inject() (
 
         ValidateReaderLogger[SafetyAndSecurity](request.userAnswers)
 
-        renderer.render("addItems/packagesCheckYourAnswers.njk", json).map(Ok(_))
+        renderer.render("addItems/packageCheckYourAnswers.njk", json).map(Ok(_))
     }
 }

--- a/app/controllers/addItems/packagesInformation/PackagesCheckYourAnswersController.scala
+++ b/app/controllers/addItems/packagesInformation/PackagesCheckYourAnswersController.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.addItems.packagesInformation
+
+import controllers.actions._
+import models.journeyDomain.SafetyAndSecurity
+import models.{Index, LocalReferenceNumber, Mode, ValidateReaderLogger}
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import renderer.Renderer
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import viewModels.sections.Section
+
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+
+class PackagesCheckYourAnswersController @Inject() (
+  override val messagesApi: MessagesApi,
+  identify: IdentifierAction,
+  getData: DataRetrievalActionProvider,
+  requireData: DataRequiredAction,
+  val controllerComponents: MessagesControllerComponents,
+  renderer: Renderer
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with ValidateReaderLogger
+    with I18nSupport {
+
+  def onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, packageIndex: Index, mode: Mode): Action[AnyContent] =
+    (identify
+      andThen getData(lrn)
+      andThen requireData).async {
+      implicit request =>
+        val json = {
+          val sections: Seq[Section] = Nil
+
+          Json.obj(
+            "sections"    -> Json.toJson(sections),
+            "nextPageUrl" -> routes.AddAnotherPackageController.onPageLoad(lrn, itemIndex, mode).url
+          )
+        }
+
+        ValidateReaderLogger[SafetyAndSecurity](request.userAnswers)
+
+        renderer.render("addItems/packagesCheckYourAnswers.njk", json).map(Ok(_))
+    }
+}

--- a/app/controllers/addItems/packagesInformation/PackagesCheckYourAnswersController.scala
+++ b/app/controllers/addItems/packagesInformation/PackagesCheckYourAnswersController.scala
@@ -24,6 +24,7 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import renderer.Renderer
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import viewModels.PackagesCheckYourAnswersViewModel
 import viewModels.sections.Section
 
 import javax.inject.Inject
@@ -47,10 +48,11 @@ class PackagesCheckYourAnswersController @Inject() (
       andThen requireData).async {
       implicit request =>
         val json = {
-          val sections: Seq[Section] = Nil
+          val section: Section =
+            PackagesCheckYourAnswersViewModel(request.userAnswers, itemIndex, packageIndex, mode).section
 
           Json.obj(
-            "sections"    -> Json.toJson(sections),
+            "section"     -> Json.toJson(section),
             "nextPageUrl" -> routes.AddAnotherPackageController.onPageLoad(lrn, itemIndex, mode).url
           )
         }

--- a/app/controllers/addItems/previousReferences/ReferenceCheckYourAnswersController.scala
+++ b/app/controllers/addItems/previousReferences/ReferenceCheckYourAnswersController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.addItems.packagesInformation
+package controllers.addItems.previousReferences
 
 import controllers.actions._
 import models.{Index, LocalReferenceNumber, Mode, ValidateReaderLogger}
@@ -23,13 +23,13 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import renderer.Renderer
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import viewModels.PackagesCheckYourAnswersViewModel
+import viewModels.ReferencesCheckYourAnswersViewModel
 import viewModels.sections.Section
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 
-class PackageCheckYourAnswersController @Inject() (
+class ReferenceCheckYourAnswersController @Inject() (
   override val messagesApi: MessagesApi,
   identify: IdentifierAction,
   getData: DataRetrievalActionProvider,
@@ -41,21 +41,21 @@ class PackageCheckYourAnswersController @Inject() (
     with ValidateReaderLogger
     with I18nSupport {
 
-  def onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, packageIndex: Index, mode: Mode): Action[AnyContent] =
+  def onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, referenceIndex: Index, mode: Mode): Action[AnyContent] =
     (identify
       andThen getData(lrn)
       andThen requireData).async {
       implicit request =>
         val json = {
           val section: Section =
-            PackagesCheckYourAnswersViewModel(request.userAnswers, itemIndex, packageIndex, mode).section
+            ReferencesCheckYourAnswersViewModel(request.userAnswers, itemIndex, referenceIndex, mode).section
 
           Json.obj(
             "section"     -> Json.toJson(section),
-            "nextPageUrl" -> routes.AddAnotherPackageController.onPageLoad(lrn, itemIndex, mode).url
+            "nextPageUrl" -> routes.AddAnotherPreviousAdministrativeReferenceController.onPageLoad(lrn, itemIndex, mode).url
           )
         }
 
-        renderer.render("addItems/packageCheckYourAnswers.njk", json).map(Ok(_))
+        renderer.render("addItems/referenceCheckYourAnswers.njk", json).map(Ok(_))
     }
 }

--- a/app/controllers/addItems/specialMentions/SpecialMentionCheckYourAnswersController.scala
+++ b/app/controllers/addItems/specialMentions/SpecialMentionCheckYourAnswersController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.addItems.packagesInformation
+package controllers.addItems.specialMentions
 
 import controllers.actions._
 import models.{Index, LocalReferenceNumber, Mode, ValidateReaderLogger}
@@ -23,13 +23,13 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import renderer.Renderer
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import viewModels.PackagesCheckYourAnswersViewModel
+import viewModels.SpecialMentionsCheckYourAnswersViewModel
 import viewModels.sections.Section
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 
-class PackageCheckYourAnswersController @Inject() (
+class SpecialMentionCheckYourAnswersController @Inject() (
   override val messagesApi: MessagesApi,
   identify: IdentifierAction,
   getData: DataRetrievalActionProvider,
@@ -41,21 +41,21 @@ class PackageCheckYourAnswersController @Inject() (
     with ValidateReaderLogger
     with I18nSupport {
 
-  def onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, packageIndex: Index, mode: Mode): Action[AnyContent] =
+  def onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, referenceIndex: Index, mode: Mode): Action[AnyContent] =
     (identify
       andThen getData(lrn)
       andThen requireData).async {
       implicit request =>
         val json = {
           val section: Section =
-            PackagesCheckYourAnswersViewModel(request.userAnswers, itemIndex, packageIndex, mode).section
+            SpecialMentionsCheckYourAnswersViewModel(request.userAnswers, itemIndex, referenceIndex, mode).section
 
           Json.obj(
             "section"     -> Json.toJson(section),
-            "nextPageUrl" -> routes.AddAnotherPackageController.onPageLoad(lrn, itemIndex, mode).url
+            "nextPageUrl" -> routes.AddAnotherSpecialMentionController.onPageLoad(lrn, itemIndex, mode).url
           )
         }
 
-        renderer.render("addItems/packageCheckYourAnswers.njk", json).map(Ok(_))
+        renderer.render("addItems/specialMentions/specialMentionCheckYourAnswers.njk", json).map(Ok(_))
     }
 }

--- a/app/controllers/addItems/specialMentions/SpecialMentionCheckYourAnswersController.scala
+++ b/app/controllers/addItems/specialMentions/SpecialMentionCheckYourAnswersController.scala
@@ -16,6 +16,7 @@
 
 package controllers.addItems.specialMentions
 
+import connectors.ReferenceDataConnector
 import controllers.actions._
 import models.{Index, LocalReferenceNumber, Mode, ValidateReaderLogger}
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -24,7 +25,6 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import renderer.Renderer
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import viewModels.SpecialMentionsCheckYourAnswersViewModel
-import viewModels.sections.Section
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
@@ -34,6 +34,7 @@ class SpecialMentionCheckYourAnswersController @Inject() (
   identify: IdentifierAction,
   getData: DataRetrievalActionProvider,
   requireData: DataRequiredAction,
+  referenceDataConnector: ReferenceDataConnector,
   val controllerComponents: MessagesControllerComponents,
   renderer: Renderer
 )(implicit ec: ExecutionContext)
@@ -46,16 +47,18 @@ class SpecialMentionCheckYourAnswersController @Inject() (
       andThen getData(lrn)
       andThen requireData).async {
       implicit request =>
-        val json = {
-          val section: Section =
-            SpecialMentionsCheckYourAnswersViewModel(request.userAnswers, itemIndex, referenceIndex, mode).section
+        referenceDataConnector.getSpecialMention().flatMap {
+          specialMentions =>
+            val json = {
+              val viewModel = SpecialMentionsCheckYourAnswersViewModel(request.userAnswers, itemIndex, referenceIndex, mode, specialMentions)
 
-          Json.obj(
-            "section"     -> Json.toJson(section),
-            "nextPageUrl" -> routes.AddAnotherSpecialMentionController.onPageLoad(lrn, itemIndex, mode).url
-          )
+              Json.obj(
+                "section"     -> Json.toJson(viewModel.section),
+                "nextPageUrl" -> routes.AddAnotherSpecialMentionController.onPageLoad(lrn, itemIndex, mode).url
+              )
+            }
+
+            renderer.render("addItems/specialMentions/specialMentionCheckYourAnswers.njk", json).map(Ok(_))
         }
-
-        renderer.render("addItems/specialMentions/specialMentionCheckYourAnswers.njk", json).map(Ok(_))
     }
 }

--- a/app/navigation/annotations/addItemsNavigators/AddItemsAdminReferenceNavigator.scala
+++ b/app/navigation/annotations/addItemsNavigators/AddItemsAdminReferenceNavigator.scala
@@ -39,8 +39,8 @@ class AddItemsAdminReferenceNavigator @Inject() () extends Navigator {
     case PreviousReferencePage(itemIndex, referenceIndex) =>
       ua => Some(previousReferencesRoutes.AddExtraInformationController.onPageLoad(ua.lrn, itemIndex, referenceIndex, NormalMode))
     case AddExtraInformationPage(itemIndex, referenceIndex) => ua => addExtraInformationPage(ua, itemIndex, referenceIndex, NormalMode)
-    case ExtraInformationPage(itemIndex, _) =>
-      ua => Some(previousReferencesRoutes.AddAnotherPreviousAdministrativeReferenceController.onPageLoad(ua.lrn, itemIndex, NormalMode))
+    case ExtraInformationPage(itemIndex, referenceIndex) =>
+      ua => Some(previousReferencesRoutes.ReferenceCheckYourAnswersController.onPageLoad(ua.lrn, itemIndex, referenceIndex, NormalMode))
     case AddAnotherPreviousAdministrativeReferencePage(itemIndex) => ua => addAnotherPreviousAdministrativeReferenceNormalModeRoute(itemIndex, ua)
   }
 
@@ -51,8 +51,8 @@ class AddItemsAdminReferenceNavigator @Inject() () extends Navigator {
     case PreviousReferencePage(itemIndex, referenceIndex) =>
       ua => Some(previousReferencesRoutes.AddExtraInformationController.onPageLoad(ua.lrn, itemIndex, referenceIndex, CheckMode))
     case AddExtraInformationPage(itemIndex, referenceIndex) => ua => addExtraInformationPage(ua, itemIndex, referenceIndex, CheckMode)
-    case ExtraInformationPage(itemIndex, _) =>
-      ua => Some(previousReferencesRoutes.AddAnotherPreviousAdministrativeReferenceController.onPageLoad(ua.lrn, itemIndex, CheckMode))
+    case ExtraInformationPage(itemIndex, referenceIndex) =>
+      ua => Some(previousReferencesRoutes.ReferenceCheckYourAnswersController.onPageLoad(ua.lrn, itemIndex, referenceIndex, CheckMode))
     case ConfirmRemovePreviousAdministrativeReferencePage(itemIndex, _) => ua => Some(removePreviousAdministrativeReference(itemIndex, CheckMode)(ua))
     case AddAnotherPreviousAdministrativeReferencePage(itemIndex)       => ua => addAnotherPreviousAdministrativeReferenceCheckModeRoute(itemIndex, ua)
   }
@@ -122,7 +122,7 @@ class AddItemsAdminReferenceNavigator @Inject() () extends Navigator {
       case true =>
         previousReferencesRoutes.ExtraInformationController.onPageLoad(ua.lrn, itemIndex, referenceIndex, mode)
       case false =>
-        previousReferencesRoutes.AddAnotherPreviousAdministrativeReferenceController.onPageLoad(ua.lrn, itemIndex, mode)
+        previousReferencesRoutes.ReferenceCheckYourAnswersController.onPageLoad(ua.lrn, itemIndex, referenceIndex, mode)
     }
 
   private def removePreviousAdministrativeReference(itemIndex: Index, mode: Mode)(ua: UserAnswers) =

--- a/app/navigation/annotations/addItemsNavigators/AddItemsDocumentNavigator.scala
+++ b/app/navigation/annotations/addItemsNavigators/AddItemsDocumentNavigator.scala
@@ -36,8 +36,8 @@ class AddItemsDocumentNavigator @Inject() () extends Navigator {
     case DocumentReferencePage(index, documentIndex) =>
       ua => Some(controllers.addItems.documents.routes.AddExtraDocumentInformationController.onPageLoad(ua.lrn, index, documentIndex, NormalMode))
     case AddExtraDocumentInformationPage(index, documentIndex) => ua => addExtraDocumentInformationRoute(ua, index, documentIndex, NormalMode)
-    case DocumentExtraInformationPage(index, _) =>
-      ua => Some(controllers.addItems.documents.routes.AddAnotherDocumentController.onPageLoad(ua.lrn, index, NormalMode))
+    case DocumentExtraInformationPage(index, documentIndex) =>
+      ua => Some(controllers.addItems.documents.routes.DocumentCheckYourAnswersController.onPageLoad(ua.lrn, index, documentIndex, NormalMode))
     case AddAnotherDocumentPage(index)       => ua => addAnotherDocumentNormalModeRoute(ua, index)
     case ConfirmRemoveDocumentPage(index, _) => ua => Some(confirmRemoveDocumentRoute(ua, index, NormalMode))
     case TIRCarnetReferencePage(index, documentIndex) =>
@@ -51,8 +51,8 @@ class AddItemsDocumentNavigator @Inject() () extends Navigator {
     case DocumentReferencePage(index, documentIndex) =>
       ua => Some(controllers.addItems.documents.routes.AddExtraDocumentInformationController.onPageLoad(ua.lrn, index, documentIndex, CheckMode))
     case AddExtraDocumentInformationPage(index, documentIndex) => ua => addExtraDocumentInformationRoute(ua, index, documentIndex, CheckMode)
-    case DocumentExtraInformationPage(index, _) =>
-      ua => Some(controllers.addItems.documents.routes.AddAnotherDocumentController.onPageLoad(ua.lrn, index, CheckMode))
+    case DocumentExtraInformationPage(index, documentIndex) =>
+      ua => Some(controllers.addItems.documents.routes.DocumentCheckYourAnswersController.onPageLoad(ua.lrn, index, documentIndex, CheckMode))
     case AddAnotherDocumentPage(index)       => ua => addAnotherDocumentCheckModeRoute(ua, index)
     case ConfirmRemoveDocumentPage(index, _) => ua => Some(confirmRemoveDocumentRoute(ua, index, CheckMode))
     case TIRCarnetReferencePage(index, documentIndex) =>
@@ -93,7 +93,7 @@ class AddItemsDocumentNavigator @Inject() () extends Navigator {
   private def addExtraDocumentInformationRoute(ua: UserAnswers, index: Index, documentIndex: Index, mode: Mode) =
     ua.get(AddExtraDocumentInformationPage(index, documentIndex)) map {
       case true  => controllers.addItems.documents.routes.DocumentExtraInformationController.onPageLoad(ua.lrn, index, documentIndex, mode)
-      case false => controllers.addItems.documents.routes.AddAnotherDocumentController.onPageLoad(ua.lrn, index, mode)
+      case false => controllers.addItems.documents.routes.DocumentCheckYourAnswersController.onPageLoad(ua.lrn, index, documentIndex, mode)
     }
 
   private def addDocumentNormalModeRoute(ua: UserAnswers, index: Index) =

--- a/app/navigation/annotations/addItemsNavigators/AddItemsPackagesInfoNavigator.scala
+++ b/app/navigation/annotations/addItemsNavigators/AddItemsPackagesInfoNavigator.scala
@@ -42,7 +42,7 @@ class AddItemsPackagesInfoNavigator @Inject() () extends Navigator {
       ua => Some(controllers.addItems.packagesInformation.routes.AddMarkController.onPageLoad(ua.lrn, itemIndex, packageIndex, NormalMode))
     case AddMarkPage(itemIndex, packageIndex) => ua => addMark(itemIndex, packageIndex, ua, NormalMode)
     case DeclareMarkPage(itemIndex, packageIndex) =>
-      ua => Some(controllers.addItems.packagesInformation.routes.PackagesCheckYourAnswersController.onPageLoad(ua.lrn, itemIndex, packageIndex, NormalMode))
+      ua => Some(controllers.addItems.packagesInformation.routes.PackageCheckYourAnswersController.onPageLoad(ua.lrn, itemIndex, packageIndex, NormalMode))
     case AddAnotherPackagePage(itemIndex) => ua => addAnotherPackageNormalMode(itemIndex, ua)
     case RemovePackagePage(itemIndex)     => ua => Some(removePackage(itemIndex, NormalMode)(ua))
   }
@@ -55,7 +55,7 @@ class AddItemsPackagesInfoNavigator @Inject() () extends Navigator {
       ua => Some(controllers.addItems.packagesInformation.routes.AddMarkController.onPageLoad(ua.lrn, itemIndex, packageIndex, CheckMode))
     case AddMarkPage(itemIndex, packageIndex) => ua => addMark(itemIndex, packageIndex, ua, CheckMode)
     case DeclareMarkPage(itemIndex, packageIndex) =>
-      ua => Some(controllers.addItems.packagesInformation.routes.PackagesCheckYourAnswersController.onPageLoad(ua.lrn, itemIndex, packageIndex, CheckMode))
+      ua => Some(controllers.addItems.packagesInformation.routes.PackageCheckYourAnswersController.onPageLoad(ua.lrn, itemIndex, packageIndex, CheckMode))
     case AddAnotherPackagePage(itemIndex) => ua => addAnotherPackageCheckMode(itemIndex, ua)
     case RemovePackagePage(itemIndex)     => ua => Some(removePackage(itemIndex, CheckMode)(ua))
   }
@@ -85,7 +85,7 @@ class AddItemsPackagesInfoNavigator @Inject() () extends Navigator {
       case Some(true) =>
         Some(controllers.addItems.packagesInformation.routes.DeclareMarkController.onPageLoad(ua.lrn, itemIndex, packageIndex, mode))
       case Some(false) =>
-        Some(controllers.addItems.packagesInformation.routes.PackagesCheckYourAnswersController.onPageLoad(ua.lrn, itemIndex, packageIndex, mode))
+        Some(controllers.addItems.packagesInformation.routes.PackageCheckYourAnswersController.onPageLoad(ua.lrn, itemIndex, packageIndex, mode))
       case _ =>
         Some(mainRoutes.SessionExpiredController.onPageLoad())
     }

--- a/app/navigation/annotations/addItemsNavigators/AddItemsPackagesInfoNavigator.scala
+++ b/app/navigation/annotations/addItemsNavigators/AddItemsPackagesInfoNavigator.scala
@@ -40,9 +40,9 @@ class AddItemsPackagesInfoNavigator @Inject() () extends Navigator {
       ua => Some(controllers.addItems.packagesInformation.routes.DeclareMarkController.onPageLoad(ua.lrn, itemIndex, packageIndex, NormalMode))
     case TotalPiecesPage(itemIndex, packageIndex) =>
       ua => Some(controllers.addItems.packagesInformation.routes.AddMarkController.onPageLoad(ua.lrn, itemIndex, packageIndex, NormalMode))
-    case AddMarkPage(itemIndex, packageIndex) => ua => addMarkNormalMode(itemIndex, packageIndex, ua)
-    case DeclareMarkPage(itemIndex, _) =>
-      ua => Some(controllers.addItems.packagesInformation.routes.AddAnotherPackageController.onPageLoad(ua.lrn, itemIndex, NormalMode))
+    case AddMarkPage(itemIndex, packageIndex) => ua => addMark(itemIndex, packageIndex, ua, NormalMode)
+    case DeclareMarkPage(itemIndex, packageIndex) =>
+      ua => Some(controllers.addItems.packagesInformation.routes.PackagesCheckYourAnswersController.onPageLoad(ua.lrn, itemIndex, packageIndex, NormalMode))
     case AddAnotherPackagePage(itemIndex) => ua => addAnotherPackageNormalMode(itemIndex, ua)
     case RemovePackagePage(itemIndex)     => ua => Some(removePackage(itemIndex, NormalMode)(ua))
   }
@@ -53,9 +53,9 @@ class AddItemsPackagesInfoNavigator @Inject() () extends Navigator {
       ua => Some(controllers.addItems.packagesInformation.routes.DeclareMarkController.onPageLoad(ua.lrn, itemIndex, packageIndex, CheckMode))
     case TotalPiecesPage(itemIndex, packageIndex) =>
       ua => Some(controllers.addItems.packagesInformation.routes.AddMarkController.onPageLoad(ua.lrn, itemIndex, packageIndex, CheckMode))
-    case AddMarkPage(itemIndex, packageIndex) => ua => addMarkCheckMode(itemIndex, packageIndex, ua)
-    case DeclareMarkPage(itemIndex, _) =>
-      ua => Some(controllers.addItems.packagesInformation.routes.AddAnotherPackageController.onPageLoad(ua.lrn, itemIndex, CheckMode))
+    case AddMarkPage(itemIndex, packageIndex) => ua => addMark(itemIndex, packageIndex, ua, CheckMode)
+    case DeclareMarkPage(itemIndex, packageIndex) =>
+      ua => Some(controllers.addItems.packagesInformation.routes.PackagesCheckYourAnswersController.onPageLoad(ua.lrn, itemIndex, packageIndex, CheckMode))
     case AddAnotherPackagePage(itemIndex) => ua => addAnotherPackageCheckMode(itemIndex, ua)
     case RemovePackagePage(itemIndex)     => ua => Some(removePackage(itemIndex, CheckMode)(ua))
   }
@@ -80,18 +80,14 @@ class AddItemsPackagesInfoNavigator @Inject() () extends Navigator {
       case _       => Some(mainRoutes.SessionExpiredController.onPageLoad())
     }
 
-  def addMarkNormalMode(itemIndex: Index, packageIndex: Index, ua: UserAnswers): Option[Call] =
+  def addMark(itemIndex: Index, packageIndex: Index, ua: UserAnswers, mode: Mode): Option[Call] =
     ua.get(AddMarkPage(itemIndex, packageIndex)) match {
-      case Some(true)  => Some(controllers.addItems.packagesInformation.routes.DeclareMarkController.onPageLoad(ua.lrn, itemIndex, packageIndex, NormalMode))
-      case Some(false) => Some(controllers.addItems.packagesInformation.routes.AddAnotherPackageController.onPageLoad(ua.lrn, itemIndex, NormalMode))
-      case _           => Some(mainRoutes.SessionExpiredController.onPageLoad())
-    }
-
-  def addMarkCheckMode(itemIndex: Index, packageIndex: Index, ua: UserAnswers): Option[Call] =
-    ua.get(AddMarkPage(itemIndex, packageIndex)) match {
-      case Some(true)  => Some(controllers.addItems.packagesInformation.routes.DeclareMarkController.onPageLoad(ua.lrn, itemIndex, packageIndex, CheckMode))
-      case Some(false) => Some(addItemsRoutes.ItemsCheckYourAnswersController.onPageLoad(ua.lrn, itemIndex))
-      case _           => Some(mainRoutes.SessionExpiredController.onPageLoad())
+      case Some(true) =>
+        Some(controllers.addItems.packagesInformation.routes.DeclareMarkController.onPageLoad(ua.lrn, itemIndex, packageIndex, mode))
+      case Some(false) =>
+        Some(controllers.addItems.packagesInformation.routes.PackagesCheckYourAnswersController.onPageLoad(ua.lrn, itemIndex, packageIndex, mode))
+      case _ =>
+        Some(mainRoutes.SessionExpiredController.onPageLoad())
     }
 
   def addAnotherPackageNormalMode(itemIndex: Index, ua: UserAnswers): Option[Call] =

--- a/app/navigation/annotations/addItemsNavigators/AddItemsSpecialMentionsNavigator.scala
+++ b/app/navigation/annotations/addItemsNavigators/AddItemsSpecialMentionsNavigator.scala
@@ -52,8 +52,8 @@ class AddItemsSpecialMentionsNavigator @Inject() () extends Navigator {
         }
     case SpecialMentionTypePage(itemIndex, referenceIndex) =>
       userAnswers => Some(routes.SpecialMentionAdditionalInfoController.onPageLoad(userAnswers.lrn, itemIndex, referenceIndex, CheckMode))
-    case SpecialMentionAdditionalInfoPage(itemIndex, _) =>
-      userAnswers => Some(routes.AddAnotherSpecialMentionController.onPageLoad(userAnswers.lrn, itemIndex, CheckMode))
+    case SpecialMentionAdditionalInfoPage(itemIndex, referenceIndex) =>
+      userAnswers => Some(routes.SpecialMentionCheckYourAnswersController.onPageLoad(userAnswers.lrn, itemIndex, referenceIndex, CheckMode))
     case AddAnotherSpecialMentionPage(itemIndex) =>
       userAnswers =>
         userAnswers.get(AddAnotherSpecialMentionPage(itemIndex)) match {
@@ -84,8 +84,8 @@ class AddItemsSpecialMentionsNavigator @Inject() () extends Navigator {
   }
 
   private def specialMentionAdditionalInfoPage: PartialFunction[Page, UserAnswers => Option[Call]] = {
-    case SpecialMentionAdditionalInfoPage(itemIndex, _) =>
-      userAnswers => Some(routes.AddAnotherSpecialMentionController.onPageLoad(userAnswers.lrn, itemIndex, NormalMode))
+    case SpecialMentionAdditionalInfoPage(itemIndex, referenceIndex) =>
+      userAnswers => Some(routes.SpecialMentionCheckYourAnswersController.onPageLoad(userAnswers.lrn, itemIndex, referenceIndex, NormalMode))
   }
 
   private def addAnotherSpecialMentionPage: PartialFunction[Page, UserAnswers => Option[Call]] = {

--- a/app/utils/AddItemsCheckYourAnswersHelper.scala
+++ b/app/utils/AddItemsCheckYourAnswersHelper.scala
@@ -284,7 +284,7 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     formatAnswer = formatAsLiteral,
     label = msg"addAnotherPackage.packageList.label".withArgs(packageIndex.display),
     id = Some(s"change-package-${packageIndex.display}"),
-    call = packageRoutes.PackageTypeController.onPageLoad(lrn, itemIndex, packageIndex, mode)
+    call = packageRoutes.PackagesCheckYourAnswersController.onPageLoad(lrn, itemIndex, packageIndex, mode)
   )
 
   def packageType(itemIndex: Index, packageIndex: Index): Option[Row] = getAnswerAndBuildRow[PackageType](

--- a/app/utils/AddItemsCheckYourAnswersHelper.scala
+++ b/app/utils/AddItemsCheckYourAnswersHelper.scala
@@ -18,6 +18,7 @@ package utils
 
 import controllers.addItems.containers.{routes => containerRoutes}
 import controllers.addItems.previousReferences.{routes => previousReferencesRoutes}
+import controllers.addItems.packagesInformation.{routes => packageRoutes}
 import controllers.addItems.routes
 import controllers.addItems.securityDetails.{routes => securityDetailsRoutes}
 import controllers.addItems.traderDetails.{routes => traderDetailsRoutes}
@@ -276,6 +277,14 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     id = s"package-${packageIndex.display}",
     changeCall = controllers.addItems.packagesInformation.routes.PackageTypeController.onPageLoad(lrn, itemIndex, packageIndex, mode),
     removeCall = controllers.addItems.packagesInformation.routes.RemovePackageController.onPageLoad(lrn, itemIndex, packageIndex, mode)
+  )
+
+  def packageSectionRow(itemIndex: Index, packageIndex: Index): Option[Row] = getAnswerAndBuildSectionRow[PackageType](
+    page = PackageTypePage(itemIndex, packageIndex),
+    formatAnswer = formatAsLiteral,
+    label = msg"addAnotherPackage.packageList.label".withArgs(packageIndex.display),
+    id = Some(s"change-package-${packageIndex.display}"),
+    call = packageRoutes.PackageTypeController.onPageLoad(lrn, itemIndex, packageIndex, mode)
   )
 
   def packageType(itemIndex: Index, packageIndex: Index): Option[Row] = getAnswerAndBuildRow[PackageType](

--- a/app/utils/AddItemsCheckYourAnswersHelper.scala
+++ b/app/utils/AddItemsCheckYourAnswersHelper.scala
@@ -17,8 +17,9 @@
 package utils
 
 import controllers.addItems.containers.{routes => containerRoutes}
-import controllers.addItems.previousReferences.{routes => previousReferencesRoutes}
+import controllers.addItems.documents.{routes => documentRoutes}
 import controllers.addItems.packagesInformation.{routes => packageRoutes}
+import controllers.addItems.previousReferences.{routes => previousReferencesRoutes}
 import controllers.addItems.routes
 import controllers.addItems.securityDetails.{routes => securityDetailsRoutes}
 import controllers.addItems.traderDetails.{routes => traderDetailsRoutes}
@@ -430,6 +431,78 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     prefix = "securityConsignorEori",
     id = None,
     call = tradersSecurityDetailsRoutes.SecurityConsignorEoriController.onPageLoad(lrn, index, mode)
+  )
+
+  def referenceTypeRow(index: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
+    page = ReferenceTypePage(index, referenceIndex),
+    formatAnswer = formatAsLiteral,
+    prefix = "referenceType",
+    id = Some(s"change-reference-type-${referenceIndex.display}"),
+    call = previousReferencesRoutes.ReferenceTypeController.onPageLoad(lrn, index, referenceIndex, mode)
+  )
+
+  def previousReferenceRow(index: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
+    page = PreviousReferencePage(index, referenceIndex),
+    formatAnswer = formatAsLiteral,
+    prefix = "previousReference",
+    id = Some(s"change-previous-reference-${referenceIndex.display}"),
+    call = previousReferencesRoutes.PreviousReferenceController.onPageLoad(lrn, index, referenceIndex, mode)
+  )
+
+  def addExtraReferenceInformationRow(index: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[Boolean](
+    page = AddExtraInformationPage(index, referenceIndex),
+    formatAnswer = formatAsYesOrNo,
+    prefix = "addExtraInformation",
+    id = Some(s"change-add-extra-reference-information-${referenceIndex.display}"),
+    call = previousReferencesRoutes.AddExtraInformationController.onPageLoad(lrn, index, referenceIndex, mode)
+  )
+
+  def extraReferenceInformationRow(index: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
+    page = ExtraInformationPage(index, referenceIndex),
+    formatAnswer = formatAsLiteral,
+    prefix = "extraInformation",
+    id = Some(s"change-extra-reference-information-${referenceIndex.display}"),
+    call = previousReferencesRoutes.ExtraInformationController.onPageLoad(lrn, index, referenceIndex, mode)
+  )
+
+  def tirCarnetReferenceRow(itemIndex: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
+    page = TIRCarnetReferencePage(itemIndex, referenceIndex),
+    formatAnswer = formatAsLiteral,
+    prefix = "tirCarnetReference",
+    id = Some(s"change-tir-carnet-reference-${referenceIndex.display}"),
+    call = documentRoutes.TIRCarnetReferenceController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
+  )
+
+  def documentTypeRow(itemIndex: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
+    page = DocumentTypePage(itemIndex, referenceIndex),
+    formatAnswer = formatAsLiteral,
+    prefix = "documentType",
+    id = Some(s"change-document-type-${referenceIndex.display}"),
+    call = documentRoutes.DocumentTypeController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
+  )
+
+  def documentReferenceRow(itemIndex: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
+    page = DocumentReferencePage(itemIndex, referenceIndex),
+    formatAnswer = formatAsLiteral,
+    prefix = "documentReference",
+    id = Some(s"change-document-reference-${referenceIndex.display}"),
+    call = documentRoutes.DocumentReferenceController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
+  )
+
+  def addExtraDocumentInformationRow(itemIndex: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[Boolean](
+    page = AddExtraDocumentInformationPage(itemIndex, referenceIndex),
+    formatAnswer = formatAsYesOrNo,
+    prefix = "addExtraDocumentInformation",
+    id = Some(s"change-add-extra-document-information-${referenceIndex.display}"),
+    call = documentRoutes.AddExtraDocumentInformationController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
+  )
+
+  def extraDocumentInformationRow(itemIndex: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
+    page = DocumentExtraInformationPage(itemIndex, referenceIndex),
+    formatAnswer = formatAsLiteral,
+    prefix = "documentExtraInformation",
+    id = Some(s"change-extra-document-information-${referenceIndex.display}"),
+    call = documentRoutes.DocumentExtraInformationController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
   )
 
   private def getAnswerAndBuildPreviousReferenceRow(

--- a/app/utils/AddItemsCheckYourAnswersHelper.scala
+++ b/app/utils/AddItemsCheckYourAnswersHelper.scala
@@ -282,7 +282,7 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     page = PackageTypePage(itemIndex, packageIndex),
     formatAnswer = formatAsLiteral,
     prefix = "packageType",
-    id = Some(s"change-package-${packageIndex.display}"),
+    id = Some("change-package-type"),
     call = controllers.addItems.packagesInformation.routes.PackageTypeController.onPageLoad(lrn, itemIndex, packageIndex, mode)
   )
 
@@ -290,7 +290,7 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     page = HowManyPackagesPage(itemIndex, packageIndex),
     formatAnswer = formatAsLiteral,
     prefix = "howManyPackages",
-    id = None,
+    id = Some("change-number-of-packages"),
     call = controllers.addItems.packagesInformation.routes.HowManyPackagesController.onPageLoad(lrn, itemIndex, packageIndex, mode)
   )
 
@@ -298,8 +298,24 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     page = TotalPiecesPage(itemIndex, packageIndex),
     formatAnswer = formatAsLiteral,
     prefix = "totalPieces",
-    id = None,
+    id = Some("change-total-pieces"),
     call = controllers.addItems.packagesInformation.routes.TotalPiecesController.onPageLoad(lrn, itemIndex, packageIndex, mode)
+  )
+
+  def addMark(itemIndex: Index, packageIndex: Index): Option[Row] = getAnswerAndBuildRow[Boolean](
+    page = AddMarkPage(itemIndex, packageIndex),
+    formatAnswer = formatAsYesOrNo,
+    prefix = "addMark",
+    id = Some("change-add-mark"),
+    call = controllers.addItems.packagesInformation.routes.AddMarkController.onPageLoad(lrn, itemIndex, packageIndex, mode)
+  )
+
+  def mark(itemIndex: Index, packageIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
+    page = DeclareMarkPage(itemIndex, packageIndex),
+    formatAnswer = formatAsLiteral,
+    prefix = "declareMark",
+    id = Some("change-mark"),
+    call = controllers.addItems.packagesInformation.routes.DeclareMarkController.onPageLoad(lrn, itemIndex, packageIndex, mode)
   )
 
   def addAnotherPackage(itemIndex: Index, content: Text): AddAnotherViewModel = {

--- a/app/utils/AddItemsCheckYourAnswersHelper.scala
+++ b/app/utils/AddItemsCheckYourAnswersHelper.scala
@@ -80,8 +80,8 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
         buildSectionRow(
           label = msg"addDocuments.documentList.label".withArgs(documentIndex.display),
           answer = label,
-          id = Some(s"change-document-${index.display}-${documentIndex.display}"),
-          call = controllers.addItems.documents.routes.DocumentTypeController.onPageLoad(lrn, index, documentIndex, mode)
+          id = Some(s"change-document-${documentIndex.display}"),
+          call = controllers.addItems.documents.routes.DocumentCheckYourAnswersController.onPageLoad(lrn, index, documentIndex, mode)
         )
     )
 
@@ -236,8 +236,8 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
         buildSectionRow(
           label = msg"addAdministrativeReference.administrativeReferenceList.label".withArgs(referenceIndex.display),
           answer = answer,
-          id = Some(s"change-item-${index.display}-${referenceIndex.display}"),
-          call = previousReferencesRoutes.ReferenceTypeController.onPageLoad(lrn, index, referenceIndex, mode)
+          id = Some(s"change-reference-${referenceIndex.display}"),
+          call = previousReferencesRoutes.ReferenceCheckYourAnswersController.onPageLoad(lrn, index, referenceIndex, mode)
         )
     )
 

--- a/app/utils/AddItemsCheckYourAnswersHelper.scala
+++ b/app/utils/AddItemsCheckYourAnswersHelper.scala
@@ -451,13 +451,18 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     call = tradersSecurityDetailsRoutes.SecurityConsignorEoriController.onPageLoad(lrn, index, mode)
   )
 
-  def referenceTypeRow(index: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
-    page = ReferenceTypePage(index, referenceIndex),
-    formatAnswer = formatAsLiteral,
-    prefix = "referenceType",
-    id = Some("change-reference-type"),
-    call = previousReferencesRoutes.ReferenceTypeController.onPageLoad(lrn, index, referenceIndex, mode)
-  )
+  def referenceTypeRow(index: Index, referenceIndex: Index, documents: PreviousReferencesDocumentTypeList): Option[Row] =
+    getAnswerAndBuildPreviousReferenceRow(
+      page = ReferenceTypePage(index, referenceIndex),
+      documents = documents,
+      buildRow = answer =>
+        buildRow(
+          prefix = "referenceType",
+          answer = answer,
+          id = Some("change-reference-type"),
+          call = previousReferencesRoutes.ReferenceTypeController.onPageLoad(lrn, index, referenceIndex, mode)
+        )
+    )
 
   def previousReferenceRow(index: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
     page = PreviousReferencePage(index, referenceIndex),
@@ -491,36 +496,43 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     call = documentRoutes.TIRCarnetReferenceController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
   )
 
-  def documentTypeRow(itemIndex: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
-    page = DocumentTypePage(itemIndex, referenceIndex),
-    formatAnswer = formatAsLiteral,
-    prefix = "documentType",
-    id = Some("change-document-type"),
-    call = documentRoutes.DocumentTypeController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
-  )
+  def documentTypeRow(itemIndex: Index, documentIndex: Index, documentTypes: DocumentTypeList): Option[Row] =
+    userAnswers.get(DocumentTypePage(itemIndex, documentIndex)).flatMap {
+      answer =>
+        documentTypes.getDocumentType(answer).map {
+          documentType =>
+            val label = lit"(${documentType.code}) ${documentType.description}"
+            buildRow(
+              prefix = "documentType",
+              answer = label,
+              id = Some("change-document-type"),
+              call = documentRoutes.DocumentTypeController.onPageLoad(lrn, itemIndex, documentIndex, mode)
+            )
+        }
+    }
 
-  def documentReferenceRow(itemIndex: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
-    page = DocumentReferencePage(itemIndex, referenceIndex),
+  def documentReferenceRow(itemIndex: Index, documentIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
+    page = DocumentReferencePage(itemIndex, documentIndex),
     formatAnswer = formatAsLiteral,
     prefix = "documentReference",
     id = Some("change-document-reference"),
-    call = documentRoutes.DocumentReferenceController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
+    call = documentRoutes.DocumentReferenceController.onPageLoad(lrn, itemIndex, documentIndex, mode)
   )
 
-  def addExtraDocumentInformationRow(itemIndex: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[Boolean](
-    page = AddExtraDocumentInformationPage(itemIndex, referenceIndex),
+  def addExtraDocumentInformationRow(itemIndex: Index, documentIndex: Index): Option[Row] = getAnswerAndBuildRow[Boolean](
+    page = AddExtraDocumentInformationPage(itemIndex, documentIndex),
     formatAnswer = formatAsYesOrNo,
     prefix = "addExtraDocumentInformation",
     id = Some("change-add-extra-document-information"),
-    call = documentRoutes.AddExtraDocumentInformationController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
+    call = documentRoutes.AddExtraDocumentInformationController.onPageLoad(lrn, itemIndex, documentIndex, mode)
   )
 
-  def extraDocumentInformationRow(itemIndex: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
-    page = DocumentExtraInformationPage(itemIndex, referenceIndex),
+  def extraDocumentInformationRow(itemIndex: Index, documentIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
+    page = DocumentExtraInformationPage(itemIndex, documentIndex),
     formatAnswer = formatAsLiteral,
     prefix = "documentExtraInformation",
     id = Some("change-extra-document-information"),
-    call = documentRoutes.DocumentExtraInformationController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
+    call = documentRoutes.DocumentExtraInformationController.onPageLoad(lrn, itemIndex, documentIndex, mode)
   )
 
   private def getAnswerAndBuildPreviousReferenceRow(

--- a/app/utils/AddItemsCheckYourAnswersHelper.scala
+++ b/app/utils/AddItemsCheckYourAnswersHelper.scala
@@ -285,7 +285,7 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     formatAnswer = formatAsLiteral,
     label = msg"addAnotherPackage.packageList.label".withArgs(packageIndex.display),
     id = Some(s"change-package-${packageIndex.display}"),
-    call = packageRoutes.PackagesCheckYourAnswersController.onPageLoad(lrn, itemIndex, packageIndex, mode)
+    call = packageRoutes.PackageCheckYourAnswersController.onPageLoad(lrn, itemIndex, packageIndex, mode)
   )
 
   def packageType(itemIndex: Index, packageIndex: Index): Option[Row] = getAnswerAndBuildRow[PackageType](
@@ -437,7 +437,7 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     page = ReferenceTypePage(index, referenceIndex),
     formatAnswer = formatAsLiteral,
     prefix = "referenceType",
-    id = Some(s"change-reference-type-${referenceIndex.display}"),
+    id = Some("change-reference-type"),
     call = previousReferencesRoutes.ReferenceTypeController.onPageLoad(lrn, index, referenceIndex, mode)
   )
 
@@ -445,7 +445,7 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     page = PreviousReferencePage(index, referenceIndex),
     formatAnswer = formatAsLiteral,
     prefix = "previousReference",
-    id = Some(s"change-previous-reference-${referenceIndex.display}"),
+    id = Some("change-previous-reference"),
     call = previousReferencesRoutes.PreviousReferenceController.onPageLoad(lrn, index, referenceIndex, mode)
   )
 
@@ -453,7 +453,7 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     page = AddExtraInformationPage(index, referenceIndex),
     formatAnswer = formatAsYesOrNo,
     prefix = "addExtraInformation",
-    id = Some(s"change-add-extra-reference-information-${referenceIndex.display}"),
+    id = Some("change-add-extra-reference-information"),
     call = previousReferencesRoutes.AddExtraInformationController.onPageLoad(lrn, index, referenceIndex, mode)
   )
 
@@ -461,7 +461,7 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     page = ExtraInformationPage(index, referenceIndex),
     formatAnswer = formatAsLiteral,
     prefix = "extraInformation",
-    id = Some(s"change-extra-reference-information-${referenceIndex.display}"),
+    id = Some("change-extra-reference-information"),
     call = previousReferencesRoutes.ExtraInformationController.onPageLoad(lrn, index, referenceIndex, mode)
   )
 
@@ -469,7 +469,7 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     page = TIRCarnetReferencePage(itemIndex, referenceIndex),
     formatAnswer = formatAsLiteral,
     prefix = "tirCarnetReference",
-    id = Some(s"change-tir-carnet-reference-${referenceIndex.display}"),
+    id = Some("change-tir-carnet-reference"),
     call = documentRoutes.TIRCarnetReferenceController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
   )
 
@@ -477,7 +477,7 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     page = DocumentTypePage(itemIndex, referenceIndex),
     formatAnswer = formatAsLiteral,
     prefix = "documentType",
-    id = Some(s"change-document-type-${referenceIndex.display}"),
+    id = Some("change-document-type"),
     call = documentRoutes.DocumentTypeController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
   )
 
@@ -485,7 +485,7 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     page = DocumentReferencePage(itemIndex, referenceIndex),
     formatAnswer = formatAsLiteral,
     prefix = "documentReference",
-    id = Some(s"change-document-reference-${referenceIndex.display}"),
+    id = Some("change-document-reference"),
     call = documentRoutes.DocumentReferenceController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
   )
 
@@ -493,7 +493,7 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     page = AddExtraDocumentInformationPage(itemIndex, referenceIndex),
     formatAnswer = formatAsYesOrNo,
     prefix = "addExtraDocumentInformation",
-    id = Some(s"change-add-extra-document-information-${referenceIndex.display}"),
+    id = Some("change-add-extra-document-information"),
     call = documentRoutes.AddExtraDocumentInformationController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
   )
 
@@ -501,7 +501,7 @@ class AddItemsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode) exten
     page = DocumentExtraInformationPage(itemIndex, referenceIndex),
     formatAnswer = formatAsLiteral,
     prefix = "documentExtraInformation",
-    id = Some(s"change-extra-document-information-${referenceIndex.display}"),
+    id = Some("change-extra-document-information"),
     call = documentRoutes.DocumentExtraInformationController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
   )
 

--- a/app/utils/SpecialMentionsCheckYourAnswersHelper.scala
+++ b/app/utils/SpecialMentionsCheckYourAnswersHelper.scala
@@ -47,8 +47,8 @@ class SpecialMentionsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode
         buildSectionRow(
           label = msg"addAnotherSpecialMention.specialMentionList.label".withArgs(referenceIndex.display),
           answer = answer,
-          id = Some(s"change-special-mentions-${itemIndex.display}-${referenceIndex.display}"),
-          call = specialMentionRoutes.SpecialMentionTypeController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
+          id = Some(s"change-special-mention-${referenceIndex.display}"),
+          call = specialMentionRoutes.SpecialMentionCheckYourAnswersController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
         )
     )
 

--- a/app/utils/SpecialMentionsCheckYourAnswersHelper.scala
+++ b/app/utils/SpecialMentionsCheckYourAnswersHelper.scala
@@ -60,13 +60,18 @@ class SpecialMentionsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode
     call = specialMentionRoutes.AddSpecialMentionController.onPageLoad(lrn, itemIndex, mode)
   )
 
-  def specialMentionTypeRow(itemIndex: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
-    page = SpecialMentionTypePage(itemIndex, referenceIndex),
-    formatAnswer = formatAsLiteral,
-    prefix = "specialMentionType",
-    id = Some("change-special-mention-type"),
-    call = specialMentionRoutes.SpecialMentionTypeController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
-  )
+  def specialMentionTypeRow(itemIndex: Index, referenceIndex: Index, specialMentions: SpecialMentionList): Option[Row] =
+    getAnswerAndBuildSpecialMentionRow(
+      page = SpecialMentionTypePage(itemIndex, referenceIndex),
+      specialMentions = specialMentions,
+      buildRow = answer =>
+        buildRow(
+          prefix = "specialMentionType",
+          answer = answer,
+          id = Some("change-special-mention-type"),
+          call = specialMentionRoutes.SpecialMentionTypeController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
+        )
+    )
 
   def specialMentionAdditionalInfoRow(itemIndex: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
     page = SpecialMentionAdditionalInfoPage(itemIndex, referenceIndex),

--- a/app/utils/SpecialMentionsCheckYourAnswersHelper.scala
+++ b/app/utils/SpecialMentionsCheckYourAnswersHelper.scala
@@ -64,7 +64,7 @@ class SpecialMentionsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode
     page = SpecialMentionTypePage(itemIndex, referenceIndex),
     formatAnswer = formatAsLiteral,
     prefix = "specialMentionType",
-    id = None,
+    id = Some("change-special-mention-type"),
     call = specialMentionRoutes.SpecialMentionTypeController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
   )
 
@@ -72,7 +72,7 @@ class SpecialMentionsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode
     page = SpecialMentionAdditionalInfoPage(itemIndex, referenceIndex),
     formatAnswer = formatAsLiteral,
     prefix = "specialMentionAdditionalInfo",
-    id = None,
+    id = Some("change-special-mention-additional-information"),
     call = specialMentionRoutes.SpecialMentionAdditionalInfoController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
   )
 

--- a/app/utils/SpecialMentionsCheckYourAnswersHelper.scala
+++ b/app/utils/SpecialMentionsCheckYourAnswersHelper.scala
@@ -60,6 +60,22 @@ class SpecialMentionsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode
     call = specialMentionRoutes.AddSpecialMentionController.onPageLoad(lrn, itemIndex, mode)
   )
 
+  def specialMentionTypeRow(itemIndex: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
+    page = SpecialMentionTypePage(itemIndex, referenceIndex),
+    formatAnswer = formatAsLiteral,
+    prefix = "specialMentionType",
+    id = None,
+    call = specialMentionRoutes.SpecialMentionTypeController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
+  )
+
+  def specialMentionAdditionalInfoRow(itemIndex: Index, referenceIndex: Index): Option[Row] = getAnswerAndBuildRow[String](
+    page = SpecialMentionAdditionalInfoPage(itemIndex, referenceIndex),
+    formatAnswer = formatAsLiteral,
+    prefix = "specialMentionAdditionalInfo",
+    id = None,
+    call = specialMentionRoutes.SpecialMentionAdditionalInfoController.onPageLoad(lrn, itemIndex, referenceIndex, mode)
+  )
+
   def addAnother(itemIndex: Index, content: Text): AddAnotherViewModel = {
 
     val addAnotherContainerHref = userAnswers.get(AddSpecialMentionPage(itemIndex)) match {

--- a/app/utils/SpecialMentionsCheckYourAnswersHelper.scala
+++ b/app/utils/SpecialMentionsCheckYourAnswersHelper.scala
@@ -33,8 +33,8 @@ class SpecialMentionsCheckYourAnswersHelper(userAnswers: UserAnswers, mode: Mode
       buildRow = label =>
         buildRemovableRow(
           label = label,
-          id = s"special-mentions-${itemIndex.display}-${referenceIndex.display}",
-          changeCall = specialMentionRoutes.SpecialMentionTypeController.onPageLoad(lrn, itemIndex, referenceIndex, mode),
+          id = s"special-mention-${referenceIndex.display}",
+          changeCall = specialMentionRoutes.SpecialMentionCheckYourAnswersController.onPageLoad(lrn, itemIndex, referenceIndex, mode),
           removeCall = specialMentionRoutes.RemoveSpecialMentionController.onPageLoad(userAnswers.lrn, itemIndex, referenceIndex, mode)
         )
     )

--- a/app/viewModels/AddItemsCheckYourAnswersViewModel.scala
+++ b/app/viewModels/AddItemsCheckYourAnswersViewModel.scala
@@ -37,20 +37,22 @@ object AddItemsCheckYourAnswersViewModel {
     val specialMentionsCheckYourAnswers = new SpecialMentionsCheckYourAnswersHelper(userAnswers, CheckMode)
 
     AddItemsCheckYourAnswersViewModel(
-      itemsDetailsSection(checkYourAnswersHelper, index) ++
-        traderConsignorDetailsSection(checkYourAnswersHelper, index) ++
-        traderConsigneeDetailsSection(checkYourAnswersHelper, index) ++
-        packagesSections(checkYourAnswersHelper, index)(userAnswers) ++
-        containersSection(checkYourAnswersHelper, index)(userAnswers) ++
-        specialMentionsSection(specialMentionsCheckYourAnswers, index, specialMentionList)(userAnswers) ++
-        documentsSection(checkYourAnswersHelper, index, documentTypeList)(userAnswers) ++
-        referencesSection(checkYourAnswersHelper, index, previousDocumentTypes)(userAnswers) ++
-        securitySection(checkYourAnswersHelper, index) ++
+      Seq(
+        itemsDetailsSection(checkYourAnswersHelper, index),
+        traderConsignorDetailsSection(checkYourAnswersHelper, index),
+        traderConsigneeDetailsSection(checkYourAnswersHelper, index),
+        packagesSection(checkYourAnswersHelper, index)(userAnswers),
+        containersSection(checkYourAnswersHelper, index)(userAnswers),
+        specialMentionsSection(specialMentionsCheckYourAnswers, index, specialMentionList)(userAnswers),
+        documentsSection(checkYourAnswersHelper, index, documentTypeList)(userAnswers),
+        referencesSection(checkYourAnswersHelper, index, previousDocumentTypes)(userAnswers),
+        securitySection(checkYourAnswersHelper, index),
         traderSecuritySection(checkYourAnswersHelper, index)
+      )
     )
   }
 
-  private def traderSecuritySection(checkYourAnswersHelper: AddItemsCheckYourAnswersHelper, index: Index) = Seq(
+  private def traderSecuritySection(checkYourAnswersHelper: AddItemsCheckYourAnswersHelper, index: Index) =
     Section(
       msg"addItems.checkYourAnswersLabel.security",
       Seq(
@@ -64,9 +66,8 @@ object AddItemsCheckYourAnswersViewModel {
         checkYourAnswersHelper.securityConsigneeAddress(index)
       ).flatten
     )
-  )
 
-  private def securitySection(checkYourAnswersHelper: AddItemsCheckYourAnswersHelper, index: Index) = Seq(
+  private def securitySection(checkYourAnswersHelper: AddItemsCheckYourAnswersHelper, index: Index) =
     Section(
       msg"addItems.checkYourAnswersLabel.safetyAndSecurity",
       Seq(
@@ -76,9 +77,8 @@ object AddItemsCheckYourAnswersViewModel {
         checkYourAnswersHelper.dangerousGoodsCode(index)
       ).flatten
     )
-  )
 
-  private def itemsDetailsSection(checkYourAnswersHelper: AddItemsCheckYourAnswersHelper, index: Index) = Seq(
+  private def itemsDetailsSection(checkYourAnswersHelper: AddItemsCheckYourAnswersHelper, index: Index) =
     Section(
       msg"addItems.checkYourAnswersLabel.itemDetails",
       Seq(
@@ -90,9 +90,8 @@ object AddItemsCheckYourAnswersViewModel {
         checkYourAnswersHelper.commodityCode(index)
       ).flatten
     )
-  )
 
-  private def traderConsignorDetailsSection(checkYourAnswersHelper: AddItemsCheckYourAnswersHelper, index: Index) = Seq(
+  private def traderConsignorDetailsSection(checkYourAnswersHelper: AddItemsCheckYourAnswersHelper, index: Index) =
     Section(
       msg"addItems.checkYourAnswersLabel.traderDetails",
       msg"addItems.checkYourAnswersLabel.traderDetails.consignor",
@@ -103,9 +102,8 @@ object AddItemsCheckYourAnswersViewModel {
         checkYourAnswersHelper.traderDetailsConsignorAddress(index)
       ).flatten
     )
-  )
 
-  private def traderConsigneeDetailsSection(checkYourAnswersHelper: AddItemsCheckYourAnswersHelper, index: Index) = Seq(
+  private def traderConsigneeDetailsSection(checkYourAnswersHelper: AddItemsCheckYourAnswersHelper, index: Index) =
     Section(
       None,
       Some(msg"addItems.checkYourAnswersLabel.traderDetails.consignee"),
@@ -117,36 +115,18 @@ object AddItemsCheckYourAnswersViewModel {
       ).flatten,
       None
     )
-  )
 
-  private def packagesSections(checkYourAnswersHelper: AddItemsCheckYourAnswersHelper, index: Index)(implicit userAnswers: UserAnswers): Seq[Section] = {
-    val numberOfPackages = userAnswers.get(DeriveNumberOfPackages(index)).getOrElse(0)
-    List.range(0, numberOfPackages).map {
-      packagePosition =>
-        val isFirst = packagePosition == 0
-        val isLast  = packagePosition == numberOfPackages - 1
-        packagesSection(checkYourAnswersHelper, index, Index(packagePosition), isFirst, isLast)
-    }
-  }
-
-  private def packagesSection(
-    checkYourAnswersHelper: AddItemsCheckYourAnswersHelper,
-    index: Index,
-    packageIndex: Index,
-    isFirst: Boolean,
-    isLast: Boolean
-  ): Section = {
-    val packageRows: Seq[SummaryList.Row] = Seq(
-      checkYourAnswersHelper.packageType(index, packageIndex),
-      checkYourAnswersHelper.totalPieces(index, packageIndex),
-      checkYourAnswersHelper.numberOfPackages(index, packageIndex)
-    ).flatten
+  private def packagesSection(checkYourAnswersHelper: AddItemsCheckYourAnswersHelper, index: Index)(implicit userAnswers: UserAnswers): Section = {
+    val packageRows: Seq[SummaryList.Row] =
+      List.range(0, userAnswers.get(DeriveNumberOfPackages(index)).getOrElse(0)).flatMap {
+        packagePosition =>
+          checkYourAnswersHelper.packageSectionRow(index, Index(packagePosition))
+      }
 
     Section(
-      if (isFirst) Some(msg"addItems.checkYourAnswersLabel.packages") else None,
-      msg"addAnotherPackage.packageList.label".withArgs(packageIndex.display),
+      msg"addItems.checkYourAnswersLabel.packages",
       packageRows,
-      if (isLast) Some(checkYourAnswersHelper.addAnotherPackage(index, msg"addItems.checkYourAnswersLabel.packages.addRemove")) else None
+      checkYourAnswersHelper.addAnotherPackage(index, msg"addItems.checkYourAnswersLabel.packages.addRemove")
     )
   }
 
@@ -161,12 +141,10 @@ object AddItemsCheckYourAnswersViewModel {
           checkYourAnswersHelper.previousReferenceSectionRow(index, Index(position), previousDocumentTypes)
       }
 
-    Seq(
-      Section(
-        msg"addItems.checkYourAnswersLabel.references",
-        Seq(checkYourAnswersHelper.addAdministrativeReference(index).toSeq, referencesRows).flatten,
-        checkYourAnswersHelper.addAnotherPreviousReferences(index, msg"addItems.checkYourAnswersLabel.references.addRemove")
-      )
+    Section(
+      msg"addItems.checkYourAnswersLabel.references",
+      Seq(checkYourAnswersHelper.addAdministrativeReference(index).toSeq, referencesRows).flatten,
+      checkYourAnswersHelper.addAnotherPreviousReferences(index, msg"addItems.checkYourAnswersLabel.references.addRemove")
     )
   }
 
@@ -179,46 +157,40 @@ object AddItemsCheckYourAnswersViewModel {
           checkYourAnswersHelper.documentSectionRow(index, Index(documentPosition), documentTypeList)
       }
 
-    Seq(
-      Section(
-        msg"addItems.checkYourAnswersLabel.documents",
-        Seq(checkYourAnswersHelper.addDocuments(index).toSeq, documentRows).flatten,
-        checkYourAnswersHelper.addAnotherDocument(index, msg"addItems.checkYourAnswersLabel.documents.addRemove")
-      )
+    Section(
+      msg"addItems.checkYourAnswersLabel.documents",
+      Seq(checkYourAnswersHelper.addDocuments(index).toSeq, documentRows).flatten,
+      checkYourAnswersHelper.addAnotherDocument(index, msg"addItems.checkYourAnswersLabel.documents.addRemove")
     )
   }
 
-  private def containersSection(checkYourAnswersHelper: AddItemsCheckYourAnswersHelper, index: Index)(implicit userAnswers: UserAnswers): Seq[Section] = {
+  private def containersSection(checkYourAnswersHelper: AddItemsCheckYourAnswersHelper, index: Index)(implicit userAnswers: UserAnswers): Section = {
     val containerRows: Seq[SummaryList.Row] =
       List.range(0, userAnswers.get(DeriveNumberOfContainers(index)).getOrElse(0)).flatMap {
         containerPosition =>
           checkYourAnswersHelper.containerSectionRow(index, Index(containerPosition))
       }
 
-    Seq(
-      Section(
-        msg"addItems.checkYourAnswersLabel.containers",
-        containerRows,
-        checkYourAnswersHelper.addAnotherContainer(index, msg"addItems.checkYourAnswersLabel.containers.addRemove")
-      )
+    Section(
+      msg"addItems.checkYourAnswersLabel.containers",
+      containerRows,
+      checkYourAnswersHelper.addAnotherContainer(index, msg"addItems.checkYourAnswersLabel.containers.addRemove")
     )
   }
 
   private def specialMentionsSection(checkYourAnswersHelper: SpecialMentionsCheckYourAnswersHelper, index: Index, specialMentionList: SpecialMentionList)(
     implicit userAnswers: UserAnswers
-  ): Seq[Section] = {
+  ): Section = {
     val containerRows: Seq[SummaryList.Row] =
       List.range(0, userAnswers.get(DeriveNumberOfSpecialMentions(index)).getOrElse(0)).flatMap {
         containerPosition =>
           checkYourAnswersHelper.specialMentionSectionRow(index, Index(containerPosition), specialMentionList)
       }
 
-    Seq(
-      Section(
-        msg"addItems.checkYourAnswersLabel.specialMentions",
-        Seq(checkYourAnswersHelper.addSpecialMention(index).toSeq, containerRows).flatten,
-        checkYourAnswersHelper.addAnother(index, msg"addItems.checkYourAnswersLabel.specialMentions.addRemove")
-      )
+    Section(
+      msg"addItems.checkYourAnswersLabel.specialMentions",
+      Seq(checkYourAnswersHelper.addSpecialMention(index).toSeq, containerRows).flatten,
+      checkYourAnswersHelper.addAnother(index, msg"addItems.checkYourAnswersLabel.specialMentions.addRemove")
     )
   }
 

--- a/app/viewModels/DocumentsCheckYourAnswersViewModel.scala
+++ b/app/viewModels/DocumentsCheckYourAnswersViewModel.scala
@@ -16,7 +16,8 @@
 
 package viewModels
 
-import models.{Index, Mode, UserAnswers}
+import models.{DocumentTypeList, Index, Mode, UserAnswers}
+import pages.addItems.TIRCarnetReferencePage
 import uk.gov.hmrc.viewmodels.SummaryList
 import utils.AddItemsCheckYourAnswersHelper
 import viewModels.sections.Section
@@ -27,19 +28,27 @@ object DocumentsCheckYourAnswersViewModel {
     userAnswers: UserAnswers,
     itemIndex: Index,
     documentIndex: Index,
-    mode: Mode
+    mode: Mode,
+    documentTypes: DocumentTypeList
   ): DocumentsCheckYourAnswersViewModel = {
 
     val checkYourAnswersHelper = new AddItemsCheckYourAnswersHelper(userAnswers, mode)
 
     def documentRows: Seq[SummaryList.Row] =
-      Seq(
-        checkYourAnswersHelper.tirCarnetReferenceRow(itemIndex, documentIndex),
-        checkYourAnswersHelper.documentTypeRow(itemIndex, documentIndex),
-        checkYourAnswersHelper.documentReferenceRow(itemIndex, documentIndex),
-        checkYourAnswersHelper.addExtraDocumentInformationRow(itemIndex, documentIndex),
-        checkYourAnswersHelper.extraDocumentInformationRow(itemIndex, documentIndex)
-      ).flatten
+      (userAnswers.get(TIRCarnetReferencePage(itemIndex, documentIndex)) match {
+        case Some(_) =>
+          Seq(
+            checkYourAnswersHelper.tirCarnetReferenceRow(itemIndex, documentIndex),
+            checkYourAnswersHelper.extraDocumentInformationRow(itemIndex, documentIndex)
+          )
+        case None =>
+          Seq(
+            checkYourAnswersHelper.documentTypeRow(itemIndex, documentIndex, documentTypes),
+            checkYourAnswersHelper.documentReferenceRow(itemIndex, documentIndex),
+            checkYourAnswersHelper.addExtraDocumentInformationRow(itemIndex, documentIndex),
+            checkYourAnswersHelper.extraDocumentInformationRow(itemIndex, documentIndex)
+          )
+      }).flatten
 
     DocumentsCheckYourAnswersViewModel(
       Section(documentRows)

--- a/app/viewModels/DocumentsCheckYourAnswersViewModel.scala
+++ b/app/viewModels/DocumentsCheckYourAnswersViewModel.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewModels
+
+import models.{Index, Mode, UserAnswers}
+import uk.gov.hmrc.viewmodels.SummaryList
+import utils.AddItemsCheckYourAnswersHelper
+import viewModels.sections.Section
+
+object DocumentsCheckYourAnswersViewModel {
+
+  def apply(
+    userAnswers: UserAnswers,
+    itemIndex: Index,
+    documentIndex: Index,
+    mode: Mode
+  ): DocumentsCheckYourAnswersViewModel = {
+
+    val checkYourAnswersHelper = new AddItemsCheckYourAnswersHelper(userAnswers, mode)
+
+    def documentRows: Seq[SummaryList.Row] =
+      Seq(
+        checkYourAnswersHelper.tirCarnetReferenceRow(itemIndex, documentIndex),
+        checkYourAnswersHelper.documentTypeRow(itemIndex, documentIndex),
+        checkYourAnswersHelper.documentReferenceRow(itemIndex, documentIndex),
+        checkYourAnswersHelper.addExtraDocumentInformationRow(itemIndex, documentIndex),
+        checkYourAnswersHelper.extraDocumentInformationRow(itemIndex, documentIndex)
+      ).flatten
+
+    DocumentsCheckYourAnswersViewModel(
+      Section(documentRows)
+    )
+  }
+
+}
+
+case class DocumentsCheckYourAnswersViewModel(section: Section)

--- a/app/viewModels/PackagesCheckYourAnswersViewModel.scala
+++ b/app/viewModels/PackagesCheckYourAnswersViewModel.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewModels
+
+import models.{Index, Mode, UserAnswers}
+import uk.gov.hmrc.viewmodels.SummaryList
+import utils.AddItemsCheckYourAnswersHelper
+import viewModels.sections.Section
+
+object PackagesCheckYourAnswersViewModel {
+
+  def apply(
+    userAnswers: UserAnswers,
+    itemIndex: Index,
+    packageIndex: Index,
+    mode: Mode
+  ): PackagesCheckYourAnswersViewModel = {
+
+    val checkYourAnswersHelper = new AddItemsCheckYourAnswersHelper(userAnswers, mode)
+
+    def packageRows: Seq[SummaryList.Row] =
+      Seq(
+        checkYourAnswersHelper.packageType(itemIndex, packageIndex),
+        checkYourAnswersHelper.totalPieces(itemIndex, packageIndex),
+        checkYourAnswersHelper.numberOfPackages(itemIndex, packageIndex),
+        checkYourAnswersHelper.addMark(itemIndex, packageIndex),
+        checkYourAnswersHelper.mark(itemIndex, packageIndex)
+      ).flatten
+
+    PackagesCheckYourAnswersViewModel(
+      Section(packageRows)
+    )
+  }
+
+}
+
+case class PackagesCheckYourAnswersViewModel(section: Section)

--- a/app/viewModels/ReferencesCheckYourAnswersViewModel.scala
+++ b/app/viewModels/ReferencesCheckYourAnswersViewModel.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewModels
+
+import models.{Index, Mode, UserAnswers}
+import uk.gov.hmrc.viewmodels.SummaryList
+import utils.AddItemsCheckYourAnswersHelper
+import viewModels.sections.Section
+
+object ReferencesCheckYourAnswersViewModel {
+
+  def apply(
+    userAnswers: UserAnswers,
+    itemIndex: Index,
+    referenceIndex: Index,
+    mode: Mode
+  ): ReferencesCheckYourAnswersViewModel = {
+
+    val checkYourAnswersHelper = new AddItemsCheckYourAnswersHelper(userAnswers, mode)
+
+    def referenceRows: Seq[SummaryList.Row] =
+      Seq(
+        checkYourAnswersHelper.referenceTypeRow(itemIndex, referenceIndex),
+        checkYourAnswersHelper.previousReferenceRow(itemIndex, referenceIndex),
+        checkYourAnswersHelper.addExtraReferenceInformationRow(itemIndex, referenceIndex),
+        checkYourAnswersHelper.extraReferenceInformationRow(itemIndex, referenceIndex)
+      ).flatten
+
+    ReferencesCheckYourAnswersViewModel(
+      Section(referenceRows)
+    )
+  }
+
+}
+
+case class ReferencesCheckYourAnswersViewModel(section: Section)

--- a/app/viewModels/ReferencesCheckYourAnswersViewModel.scala
+++ b/app/viewModels/ReferencesCheckYourAnswersViewModel.scala
@@ -16,7 +16,7 @@
 
 package viewModels
 
-import models.{Index, Mode, UserAnswers}
+import models.{Index, Mode, PreviousReferencesDocumentTypeList, UserAnswers}
 import uk.gov.hmrc.viewmodels.SummaryList
 import utils.AddItemsCheckYourAnswersHelper
 import viewModels.sections.Section
@@ -27,14 +27,15 @@ object ReferencesCheckYourAnswersViewModel {
     userAnswers: UserAnswers,
     itemIndex: Index,
     referenceIndex: Index,
-    mode: Mode
+    mode: Mode,
+    previousReferencesDocumentTypes: PreviousReferencesDocumentTypeList
   ): ReferencesCheckYourAnswersViewModel = {
 
     val checkYourAnswersHelper = new AddItemsCheckYourAnswersHelper(userAnswers, mode)
 
     def referenceRows: Seq[SummaryList.Row] =
       Seq(
-        checkYourAnswersHelper.referenceTypeRow(itemIndex, referenceIndex),
+        checkYourAnswersHelper.referenceTypeRow(itemIndex, referenceIndex, previousReferencesDocumentTypes),
         checkYourAnswersHelper.previousReferenceRow(itemIndex, referenceIndex),
         checkYourAnswersHelper.addExtraReferenceInformationRow(itemIndex, referenceIndex),
         checkYourAnswersHelper.extraReferenceInformationRow(itemIndex, referenceIndex)

--- a/app/viewModels/SpecialMentionsCheckYourAnswersViewModel.scala
+++ b/app/viewModels/SpecialMentionsCheckYourAnswersViewModel.scala
@@ -16,7 +16,7 @@
 
 package viewModels
 
-import models.{Index, Mode, UserAnswers}
+import models.{Index, Mode, SpecialMentionList, UserAnswers}
 import uk.gov.hmrc.viewmodels.SummaryList
 import utils.SpecialMentionsCheckYourAnswersHelper
 import viewModels.sections.Section
@@ -27,14 +27,15 @@ object SpecialMentionsCheckYourAnswersViewModel {
     userAnswers: UserAnswers,
     itemIndex: Index,
     referenceIndex: Index,
-    mode: Mode
+    mode: Mode,
+    specialMentions: SpecialMentionList
   ): SpecialMentionsCheckYourAnswersViewModel = {
 
     val checkYourAnswersHelper = new SpecialMentionsCheckYourAnswersHelper(userAnswers, mode)
 
     def specialMentionRows: Seq[SummaryList.Row] =
       Seq(
-        checkYourAnswersHelper.specialMentionTypeRow(itemIndex, referenceIndex),
+        checkYourAnswersHelper.specialMentionTypeRow(itemIndex, referenceIndex, specialMentions),
         checkYourAnswersHelper.specialMentionAdditionalInfoRow(itemIndex, referenceIndex)
       ).flatten
 

--- a/app/viewModels/SpecialMentionsCheckYourAnswersViewModel.scala
+++ b/app/viewModels/SpecialMentionsCheckYourAnswersViewModel.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewModels
+
+import models.{Index, Mode, UserAnswers}
+import uk.gov.hmrc.viewmodels.SummaryList
+import utils.SpecialMentionsCheckYourAnswersHelper
+import viewModels.sections.Section
+
+object SpecialMentionsCheckYourAnswersViewModel {
+
+  def apply(
+    userAnswers: UserAnswers,
+    itemIndex: Index,
+    referenceIndex: Index,
+    mode: Mode
+  ): SpecialMentionsCheckYourAnswersViewModel = {
+
+    val checkYourAnswersHelper = new SpecialMentionsCheckYourAnswersHelper(userAnswers, mode)
+
+    def specialMentionRows: Seq[SummaryList.Row] =
+      Seq(
+        checkYourAnswersHelper.specialMentionTypeRow(itemIndex, referenceIndex),
+        checkYourAnswersHelper.specialMentionAdditionalInfoRow(itemIndex, referenceIndex)
+      ).flatten
+
+    SpecialMentionsCheckYourAnswersViewModel(
+      Section(specialMentionRows)
+    )
+  }
+
+}
+
+case class SpecialMentionsCheckYourAnswersViewModel(section: Section)

--- a/conf/app.addItems.routes
+++ b/conf/app.addItems.routes
@@ -58,8 +58,8 @@ POST       /:lrn/add-items/:itemIndex/packages/:packageIndex/remove-package     
 GET        /:lrn/add-items/:itemIndex/packages/:packageIndex/change-remove-package                        controllers.addItems.packagesInformation.RemovePackageController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, packageIndex: Index, mode: Mode = CheckMode)
 POST       /:lrn/add-items/:itemIndex/packages/:packageIndex/change-remove-package                        controllers.addItems.packagesInformation.RemovePackageController.onSubmit(lrn: LocalReferenceNumber, itemIndex: Index, packageIndex: Index, mode: Mode = CheckMode)
 
-GET        /:lrn/add-items/:itemIndex/packages/:packageIndex/check-answers              controllers.addItems.packagesInformation.PackagesCheckYourAnswersController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, packageIndex: Index, mode: Mode = NormalMode)
-GET        /:lrn/add-items/:itemIndex/packages/:packageIndex/change-answers             controllers.addItems.packagesInformation.PackagesCheckYourAnswersController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, packageIndex: Index, mode: Mode = CheckMode)
+GET        /:lrn/add-items/:itemIndex/packages/:packageIndex/check-answers              controllers.addItems.packagesInformation.PackageCheckYourAnswersController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, packageIndex: Index, mode: Mode = NormalMode)
+GET        /:lrn/add-items/:itemIndex/packages/:packageIndex/change-answers             controllers.addItems.packagesInformation.PackageCheckYourAnswersController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, packageIndex: Index, mode: Mode = CheckMode)
 
 GET        /:lrn/add-items/item-details/:index/commodity-code                        controllers.addItems.itemDetails.CommodityCodeController.onPageLoad(lrn: LocalReferenceNumber, index: Index, mode: Mode = NormalMode)
 POST       /:lrn/add-items/item-details/:index/commodity-code                        controllers.addItems.itemDetails.CommodityCodeController.onSubmit(lrn: LocalReferenceNumber, index: Index, mode: Mode = NormalMode)

--- a/conf/app.addItems.routes
+++ b/conf/app.addItems.routes
@@ -58,6 +58,9 @@ POST       /:lrn/add-items/:itemIndex/packages/:packageIndex/remove-package     
 GET        /:lrn/add-items/:itemIndex/packages/:packageIndex/change-remove-package                        controllers.addItems.packagesInformation.RemovePackageController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, packageIndex: Index, mode: Mode = CheckMode)
 POST       /:lrn/add-items/:itemIndex/packages/:packageIndex/change-remove-package                        controllers.addItems.packagesInformation.RemovePackageController.onSubmit(lrn: LocalReferenceNumber, itemIndex: Index, packageIndex: Index, mode: Mode = CheckMode)
 
+GET        /:lrn/add-items/:itemIndex/packages/:packageIndex/check-answers              controllers.addItems.packagesInformation.PackagesCheckYourAnswersController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, packageIndex: Index, mode: Mode = NormalMode)
+GET        /:lrn/add-items/:itemIndex/packages/:packageIndex/change-answers             controllers.addItems.packagesInformation.PackagesCheckYourAnswersController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, packageIndex: Index, mode: Mode = CheckMode)
+
 GET        /:lrn/add-items/item-details/:index/commodity-code                        controllers.addItems.itemDetails.CommodityCodeController.onPageLoad(lrn: LocalReferenceNumber, index: Index, mode: Mode = NormalMode)
 POST       /:lrn/add-items/item-details/:index/commodity-code                        controllers.addItems.itemDetails.CommodityCodeController.onSubmit(lrn: LocalReferenceNumber, index: Index, mode: Mode = NormalMode)
 GET        /:lrn/add-items/item-details/:index/change-commodity-code                  controllers.addItems.itemDetails.CommodityCodeController.onPageLoad(lrn: LocalReferenceNumber, index: Index, mode: Mode = CheckMode)

--- a/conf/app.addItems.routes
+++ b/conf/app.addItems.routes
@@ -147,6 +147,9 @@ POST       /:lrn/add-items/:itemIndex/previous-references/:referenceIndex/extra-
 GET        /:lrn/add-items/:itemIndex/previous-references/:referenceIndex/change-extra-information                 controllers.addItems.previousReferences.ExtraInformationController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, referenceIndex: Index, mode: Mode = CheckMode)
 POST       /:lrn/add-items/:itemIndex/previous-references/:referenceIndex/change-extra-information                 controllers.addItems.previousReferences.ExtraInformationController.onSubmit(lrn: LocalReferenceNumber, itemIndex: Index, referenceIndex: Index, mode: Mode = CheckMode)
 
+GET        /:lrn/add-items/:itemIndex/previous-references/:referenceIndex/check-answers              controllers.addItems.previousReferences.ReferenceCheckYourAnswersController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, referenceIndex: Index, mode: Mode = NormalMode)
+GET        /:lrn/add-items/:itemIndex/previous-references/:referenceIndex/change-answers             controllers.addItems.previousReferences.ReferenceCheckYourAnswersController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, referenceIndex: Index, mode: Mode = CheckMode)
+
 GET        /:lrn/add-items/:itemIndex/special-mentions/add-special-mention                       controllers.addItems.specialMentions.AddSpecialMentionController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, mode: Mode = NormalMode)
 POST       /:lrn/add-items/:itemIndex/special-mentions/add-special-mention                        controllers.addItems.specialMentions.AddSpecialMentionController.onSubmit(lrn: LocalReferenceNumber, itemIndex: Index, mode: Mode = NormalMode)
 GET        /:lrn/add-items/:itemIndex/special-mentions/change-add-special-mention                controllers.addItems.specialMentions.AddSpecialMentionController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, mode: Mode = CheckMode)
@@ -171,6 +174,9 @@ GET        /:lrn/add-items/:itemIndex/special-mentions/:referenceIndex/remove-sp
 POST       /:lrn/add-items/:itemIndex/special-mentions/:referenceIndex/remove-special-mention                        controllers.addItems.specialMentions.RemoveSpecialMentionController.onSubmit(lrn: LocalReferenceNumber, itemIndex: Index, referenceIndex: Index, mode: Mode = NormalMode)
 GET        /:lrn/add-items/:itemIndex/special-mentions/:referenceIndex/change-remove-special-mention                 controllers.addItems.specialMentions.RemoveSpecialMentionController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, referenceIndex: Index, mode: Mode = CheckMode)
 POST       /:lrn/add-items/:itemIndex/special-mentions/:referenceIndex/change-remove-special-mention                 controllers.addItems.specialMentions.RemoveSpecialMentionController.onSubmit(lrn: LocalReferenceNumber, itemIndex: Index, referenceIndex: Index, mode: Mode = CheckMode)
+
+GET        /:lrn/add-items/:itemIndex/special-mentions/:referenceIndex/check-answers              controllers.addItems.specialMentions.SpecialMentionCheckYourAnswersController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, referenceIndex: Index, mode: Mode = NormalMode)
+GET        /:lrn/add-items/:itemIndex/special-mentions/:referenceIndex/change-answers             controllers.addItems.specialMentions.SpecialMentionCheckYourAnswersController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, referenceIndex: Index, mode: Mode = CheckMode)
 
 GET        /:lrn/add-items/:itemIndex/containers/:containerIndex/container-number                                    controllers.addItems.containers.ContainerNumberController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, containerIndex: Index, mode: Mode = NormalMode)
 POST       /:lrn/add-items/:itemIndex/containers/:containerIndex/container-number                                    controllers.addItems.containers.ContainerNumberController.onSubmit(lrn: LocalReferenceNumber, itemIndex: Index, containerIndex: Index, mode: Mode = NormalMode)
@@ -227,6 +233,8 @@ POST       /:lrn/add-items/:itemIndex/documents/:documentIndex/tir-carnet-refere
 GET        /:lrn/add-items/:itemIndex/documents/:documentIndex/change-tir-carnet-reference                  controllers.addItems.documents.TIRCarnetReferenceController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, documentIndex:Index, mode: Mode = CheckMode)
 POST       /:lrn/add-items/:itemIndex/documents/:documentIndex/change-tir-carnet-reference                  controllers.addItems.documents.TIRCarnetReferenceController.onSubmit(lrn: LocalReferenceNumber, itemIndex: Index, documentIndex:Index, mode: Mode = CheckMode)
 
+GET        /:lrn/add-items/:itemIndex/documents/:documentIndex/check-answers              controllers.addItems.documents.DocumentCheckYourAnswersController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, documentIndex: Index, mode: Mode = NormalMode)
+GET        /:lrn/add-items/:itemIndex/documents/:documentIndex/change-answers             controllers.addItems.documents.DocumentCheckYourAnswersController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, documentIndex: Index, mode: Mode = CheckMode)
 
 GET        /:lrn/add-items/:itemIndex/containers/:containerIndex/confirm-remove-container                        controllers.addItems.containers.ConfirmRemoveContainerController.onPageLoad(lrn: LocalReferenceNumber, itemIndex: Index, containerIndex: Index, mode: Mode = NormalMode)
 POST       /:lrn/add-items/:itemIndex/containers/:containerIndex/confirm-remove-container                        controllers.addItems.containers.ConfirmRemoveContainerController.onSubmit(lrn: LocalReferenceNumber, itemIndex: Index, containerIndex: Index, mode: Mode = NormalMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -69,7 +69,11 @@ goodsSummary.preHeading = Goods summary
 guaranteeDetails.preHeading = Guarantee details
 items.preHeading = Items
 safetyAndSecurity.preHeading = Safety and security
-packages.preHeading = Packages
+
+package.preHeading = Packages
+specialMention.preHeading = Special mentions
+document.preHeading = Produced documents and work certificates
+reference.preHeading = Previous administrative references
 
 routeDetailsCheckYourAnswers.heading = Check your answers
 routeDetailsCheckYourAnswers.title = Check your answers
@@ -825,6 +829,9 @@ extraInformation.error.required = Enter the extra information for this document
 extraInformation.error.length = The extra information for this document must be 26 characters or less
 extraInformation.error.invalid = The extra information for this document must only include letters a to z without accents, numbers 0 to 9, blank spaces, at signs (@), forward slashes, back slashes, full stops, commas, hyphens, and question marks
 
+referenceCheckYourAnswers.title = Check your answers
+referenceCheckYourAnswers.heading = Check your answers
+
 confirmRemovePreviousAdministrativeReference.title = Are you sure you want to remove this previous administrative reference?
 confirmRemovePreviousAdministrativeReference.heading = Are you sure you want to remove this previous administrative reference?
 confirmRemovePreviousAdministrativeReference.checkYourAnswersLabel = confirmRemovePreviousAdministrativeReference
@@ -847,6 +854,9 @@ specialMentionAdditionalInfo.heading = What information do you need to add for s
 specialMentionAdditionalInfo.error.required = Enter the information you need to add for special mention {0} for item {1}
 specialMentionAdditionalInfo.error.length = The information you need to add for special mention {0} for item {1} must be 70 characters or less
 specialMentionAdditionalInfo.error.invalid = The information you need to add for special mention {0} for item {1} must only include letters a to z without accents, numbers 0 to 9, blank spaces, at signs (@), forward slashes, back slashes, full stops, commas, hyphens, and question marks
+
+specialMentionCheckYourAnswers.title = Check your answers
+specialMentionCheckYourAnswers.heading = Check your answers
 
 addAnotherSpecialMention.title.singular = You have added 1 special mention for item {0}
 addAnotherSpecialMention.title.plural = You have added {0} special mentions for item {1}
@@ -918,6 +928,9 @@ documentType.title = What type of document do you need to add?
 documentType.heading = What type of document do you need to add?
 documentType.checkYourAnswersLabel = Document type
 documentType.error.required = Enter the type of document you need to add
+
+documentCheckYourAnswers.title = Check your answers
+documentCheckYourAnswers.heading = Check your answers
 
 submissionConfirmation.title = Departure declaration sent
 submissionConfirmation.heading = Departure declaration sent

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -663,8 +663,8 @@ howManyPackages.error.required = Enter how many packages have been used for item
 howManyPackages.error.wholeNumber = Enter how many packages have been used for item {0} using whole numbers
 howManyPackages.error.outOfRange = The packages used for item {0} must be between {1} and {2}
 
-packagesCheckYourAnswers.title = Check your answers
-packagesCheckYourAnswers.heading = Check your answers
+packageCheckYourAnswers.title = Check your answers
+packageCheckYourAnswers.heading = Check your answers
 
 removePackage.title = Are you sure you want to remove package {0}?
 removePackage.heading = Are you sure you want to remove package {0}?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -617,10 +617,12 @@ totalPieces.checkYourAnswersLabel = Number of pieces
 
 addMark.title = Do you need to add a mark or number for package {0}?
 addMark.heading = Do you need to add a mark or number for package {0}?
+addMark.checkYourAnswersLabel = Add a mark?
 addMark.error.required = Select yes if you need to add a mark or number for package {0}
 
 declareMark.title = What is the mark or number for package {0}?
 declareMark.heading = What is the mark or number for package {0}?
+declareMark.checkYourAnswersLabel = Mark or number
 declareMark.error.required = Enter the mark or number for package {0}
 declareMark.error.length = The mark or number for package {0} must be {1} characters or less
 declareMark.error.emptyNumberOfPackages = Mark or number for package {0} must be 1 or more

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -69,6 +69,7 @@ goodsSummary.preHeading = Goods summary
 guaranteeDetails.preHeading = Guarantee details
 items.preHeading = Items
 safetyAndSecurity.preHeading = Safety and security
+packages.preHeading = Packages
 
 routeDetailsCheckYourAnswers.heading = Check your answers
 routeDetailsCheckYourAnswers.title = Check your answers
@@ -655,6 +656,9 @@ howManyPackages.error.nonNumeric = How many packages have been used for item {0}
 howManyPackages.error.required = Enter how many packages have been used for item {0}
 howManyPackages.error.wholeNumber = Enter how many packages have been used for item {0} using whole numbers
 howManyPackages.error.outOfRange = The packages used for item {0} must be between {1} and {2}
+
+packagesCheckYourAnswers.title = Check your answers
+packagesCheckYourAnswers.heading = Check your answers
 
 removePackage.title = Are you sure you want to remove package {0}?
 removePackage.heading = Are you sure you want to remove package {0}?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -800,19 +800,19 @@ addAdministrativeReference.administrativeReferenceList.label = Proof of customs 
 
 referenceType.title = What type of reference do you want to add?
 referenceType.heading = What type of reference do you want to add?
-referenceType.checkYourAnswersLabel = referenceType
+referenceType.checkYourAnswersLabel = Reference type
 referenceType.error.required = Enter the type of reference you want to add
 
 previousReference.title = What is the previous document reference?
 previousReference.heading = What is the previous document reference?
-previousReference.checkYourAnswersLabel = What is the previous document reference?
+previousReference.checkYourAnswersLabel = Previous document reference
 previousReference.error.required = Enter the previous document reference
 previousReference.error.invalidCharacters = The previous document reference must only include letters a to z without accents, numbers 0 to 9, blank spaces, at signs (@), forward slashes, back slashes, full stops, commas, hyphens, and question marks
 previousReference.error.length = The previous document reference must be 35 characters or less
 
 addExtraInformation.title = Do you need to add any extra information for this document?
 addExtraInformation.heading = Do you need to add any extra information for this document?
-addExtraInformation.checkYourAnswersLabel = addExtraInformation
+addExtraInformation.checkYourAnswersLabel = Add extra information?
 addExtraInformation.error.required = Select yes if you need to add any extra information for this document
 
 addAnotherPreviousAdministrativeReference.title.singular = You have added 1 previous administrative reference
@@ -824,7 +824,7 @@ addAnotherPreviousAdministrativeReference.error.required = Select yes if you nee
 
 extraInformation.title = What extra information for this document do you need to add?
 extraInformation.heading = What extra information for this document do you need to add?
-extraInformation.checkYourAnswersLabel = extraInformation
+extraInformation.checkYourAnswersLabel = Extra information
 extraInformation.error.required = Enter the extra information for this document
 extraInformation.error.length = The extra information for this document must be 26 characters or less
 extraInformation.error.invalid = The extra information for this document must only include letters a to z without accents, numbers 0 to 9, blank spaces, at signs (@), forward slashes, back slashes, full stops, commas, hyphens, and question marks
@@ -847,13 +847,14 @@ specialMentionType.title = What type of special mention do you want to add for i
 specialMentionType.heading = What type of special mention do you want to add for item {0}?
 specialMentionType.error.required = Enter the type of special mention that you want to add for item {0}
 specialMentionType.error.length = SpecialMentionType must be 100 characters or less
-specialMentionType.checkYourAnswersLabel = Special mention {0}
+specialMentionType.checkYourAnswersLabel = Special mention type
 
 specialMentionAdditionalInfo.title = What information do you need to add for special mention {0} for item {1}?
 specialMentionAdditionalInfo.heading = What information do you need to add for special mention {0} for item {1}?
 specialMentionAdditionalInfo.error.required = Enter the information you need to add for special mention {0} for item {1}
 specialMentionAdditionalInfo.error.length = The information you need to add for special mention {0} for item {1} must be 70 characters or less
 specialMentionAdditionalInfo.error.invalid = The information you need to add for special mention {0} for item {1} must only include letters a to z without accents, numbers 0 to 9, blank spaces, at signs (@), forward slashes, back slashes, full stops, commas, hyphens, and question marks
+specialMentionAdditionalInfo.checkYourAnswersLabel = Additional information
 
 specialMentionCheckYourAnswers.title = Check your answers
 specialMentionCheckYourAnswers.heading = Check your answers
@@ -891,6 +892,7 @@ addAnotherContainer.containerList.label = Shipping container {0}
 addExtraDocumentInformation.title = Do you need to add any extra information for document {0}?
 addExtraDocumentInformation.heading = Do you need to add any extra information for document {0}?
 addExtraDocumentInformation.error.required = Select yes if you need to add any extra information for document {0}
+addExtraDocumentInformation.checkYourAnswersLabel = Add extra information?
 
 addDocuments.title = Do you need to add any produced documents or work certificates for item {0}?
 addDocuments.heading = Do you need to add any produced documents or work certificates for item {0}?
@@ -908,7 +910,7 @@ documentReference.error.length = The document reference must be 35 characters or
 
 documentExtraInformation.title = What extra information do you need to add for document {0}?
 documentExtraInformation.heading = What extra information do you need to add for document {0}?
-documentExtraInformation.checkYourAnswersLabel = Extra information for document {0}
+documentExtraInformation.checkYourAnswersLabel = Extra information
 documentExtraInformation.error.required = Enter the extra information for document {0}
 documentExtraInformation.error.length = Document extra information must be 26 characters or less
 documentExtraInformation.error.invalid = The extra information for this document must only include letters a to z without accents, numbers 0 to 9, ampersands (&), apostrophes, at signs (@), forward slashes, full stops, hyphens, percent signs, question marks and spaces

--- a/conf/views/addItems/documentCheckYourAnswers.njk
+++ b/conf/views/addItems/documentCheckYourAnswers.njk
@@ -1,0 +1,43 @@
+{% extends "includes/layout.njk" %}
+
+{% from "govuk/components/back-link/macro.njk"     import govukBackLink %}
+{% from "macros/title.njk"                         import title %}
+{% from "macros/section.njk"                       import section as sectionMacro %}
+{% from "govuk/components/button/macro.njk"        import govukButton %}
+
+{% block pageTitle %}
+  {{ title(messages("documentCheckYourAnswers.title")) }}
+{% endblock %}
+
+{% block mainContent %}
+
+  {{ govukBackLink({
+    text: messages("site.back")
+  }) }}
+
+  <div class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        <span class="govuk-caption-xl">{{ messages("document.preHeading") }}</span>
+
+        <h1 class="govuk-heading-xl">
+          {{ messages("documentCheckYourAnswers.heading") }}
+        </h1>
+
+        {{ sectionMacro(section.sectionTitle, section.rows) }}
+
+        {{ csrf() | safe }}
+
+        {{ govukButton({
+          text: messages("site.continue"),
+          preventDoubleClick: true,
+          href: nextPageUrl,
+          attributes: {id: "submit"}
+        }) }}
+
+      </div>
+    </div>
+  </div>
+
+{% endblock %}

--- a/conf/views/addItems/packageCheckYourAnswers.njk
+++ b/conf/views/addItems/packageCheckYourAnswers.njk
@@ -1,0 +1,43 @@
+{% extends "includes/layout.njk" %}
+
+{% from "govuk/components/back-link/macro.njk"     import govukBackLink %}
+{% from "macros/title.njk"                         import title %}
+{% from "macros/section.njk"                       import section as sectionMacro %}
+{% from "govuk/components/button/macro.njk"        import govukButton %}
+
+{% block pageTitle %}
+  {{ title(messages("packageCheckYourAnswers.title")) }}
+{% endblock %}
+
+{% block mainContent %}
+
+  {{ govukBackLink({
+    text: messages("site.back")
+  }) }}
+
+  <div class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        <span class="govuk-caption-xl">{{ messages("package.preHeading") }}</span>
+
+        <h1 class="govuk-heading-xl">
+          {{ messages("packageCheckYourAnswers.heading") }}
+        </h1>
+
+        {{ sectionMacro(section.sectionTitle, section.rows) }}
+
+        {{ csrf() | safe }}
+
+        {{ govukButton({
+          text: messages("site.continue"),
+          preventDoubleClick: true,
+          href: nextPageUrl,
+          attributes: {id: "submit"}
+        }) }}
+
+      </div>
+    </div>
+  </div>
+
+{% endblock %}

--- a/conf/views/addItems/packagesCheckYourAnswers.njk
+++ b/conf/views/addItems/packagesCheckYourAnswers.njk
@@ -1,0 +1,45 @@
+{% extends "includes/layout.njk" %}
+
+{% from "govuk/components/back-link/macro.njk"     import govukBackLink %}
+{% from "macros/title.njk"                         import title %}
+{% from "macros/section.njk"                       import section as sectionMacro %}
+{% from "govuk/components/button/macro.njk"        import govukButton %}
+
+{% block pageTitle %}
+  {{ title(messages("packagesCheckYourAnswers.title")) }}
+{% endblock %}
+
+{% block mainContent %}
+
+  {{ govukBackLink({
+    text: messages("site.back")
+  }) }}
+
+  <div class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        <span class="govuk-caption-xl">{{ messages("packages.preHeading") }}</span>
+
+        <h1 class="govuk-heading-xl">
+          {{ messages("packagesCheckYourAnswers.heading") }}
+        </h1>
+
+        {% for section in sections %}
+          {{ sectionMacro(section.sectionTitle, section.rows, section.addAnother, section.sectionSubTitle) }}
+        {% endfor %}
+
+        {{ csrf() | safe }}
+
+        {{ govukButton({
+          text: messages("site.continue"),
+          preventDoubleClick: true,
+          href: nextPageUrl,
+          attributes: {id: "submit"}
+        }) }}
+
+      </div>
+    </div>
+  </div>
+
+{% endblock %}

--- a/conf/views/addItems/packagesCheckYourAnswers.njk
+++ b/conf/views/addItems/packagesCheckYourAnswers.njk
@@ -25,9 +25,7 @@
           {{ messages("packagesCheckYourAnswers.heading") }}
         </h1>
 
-        {% for section in sections %}
-          {{ sectionMacro(section.sectionTitle, section.rows, section.addAnother, section.sectionSubTitle) }}
-        {% endfor %}
+        {{ sectionMacro(section.sectionTitle, section.rows) }}
 
         {{ csrf() | safe }}
 

--- a/conf/views/addItems/referenceCheckYourAnswers.njk
+++ b/conf/views/addItems/referenceCheckYourAnswers.njk
@@ -1,0 +1,43 @@
+{% extends "includes/layout.njk" %}
+
+{% from "govuk/components/back-link/macro.njk"     import govukBackLink %}
+{% from "macros/title.njk"                         import title %}
+{% from "macros/section.njk"                       import section as sectionMacro %}
+{% from "govuk/components/button/macro.njk"        import govukButton %}
+
+{% block pageTitle %}
+  {{ title(messages("referenceCheckYourAnswers.title")) }}
+{% endblock %}
+
+{% block mainContent %}
+
+  {{ govukBackLink({
+    text: messages("site.back")
+  }) }}
+
+  <div class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        <span class="govuk-caption-xl">{{ messages("reference.preHeading") }}</span>
+
+        <h1 class="govuk-heading-xl">
+          {{ messages("referenceCheckYourAnswers.heading") }}
+        </h1>
+
+        {{ sectionMacro(section.sectionTitle, section.rows) }}
+
+        {{ csrf() | safe }}
+
+        {{ govukButton({
+          text: messages("site.continue"),
+          preventDoubleClick: true,
+          href: nextPageUrl,
+          attributes: {id: "submit"}
+        }) }}
+
+      </div>
+    </div>
+  </div>
+
+{% endblock %}

--- a/conf/views/addItems/specialMentions/specialMentionCheckYourAnswers.njk
+++ b/conf/views/addItems/specialMentions/specialMentionCheckYourAnswers.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/button/macro.njk"        import govukButton %}
 
 {% block pageTitle %}
-  {{ title(messages("packagesCheckYourAnswers.title")) }}
+  {{ title(messages("specialMentionCheckYourAnswers.title")) }}
 {% endblock %}
 
 {% block mainContent %}
@@ -19,10 +19,10 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl">{{ messages("packages.preHeading") }}</span>
+        <span class="govuk-caption-xl">{{ messages("specialMention.preHeading") }}</span>
 
         <h1 class="govuk-heading-xl">
-          {{ messages("packagesCheckYourAnswers.heading") }}
+          {{ messages("specialMentionCheckYourAnswers.heading") }}
         </h1>
 
         {{ sectionMacro(section.sectionTitle, section.rows) }}

--- a/test/controllers/addItems/documents/AddAnotherDocumentControllerSpec.scala
+++ b/test/controllers/addItems/documents/AddAnotherDocumentControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.addItems
+package controllers.addItems.documents
 
 import base.{MockNunjucksRendererApp, SpecBase}
 import connectors.ReferenceDataConnector

--- a/test/controllers/addItems/documents/AddDocumentsControllerSpec.scala
+++ b/test/controllers/addItems/documents/AddDocumentsControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.addItems
+package controllers.addItems.documents
 
 import base.{MockNunjucksRendererApp, SpecBase}
 import controllers.{routes => mainRoutes}

--- a/test/controllers/addItems/documents/AddExtraDocumentInformationControllerSpec.scala
+++ b/test/controllers/addItems/documents/AddExtraDocumentInformationControllerSpec.scala
@@ -14,22 +14,20 @@
  * limitations under the License.
  */
 
-package controllers.addItems
+package controllers.addItems.documents
 
 import base.{MockNunjucksRendererApp, SpecBase}
-import connectors.ReferenceDataConnector
 import controllers.{routes => mainRoutes}
-import forms.addItems.DocumentTypeFormProvider
+import forms.addItems.AddExtraDocumentInformationFormProvider
 import matchers.JsonMatchers
-import models.reference.DocumentType
-import models.{DocumentTypeList, NormalMode}
+import models.{NormalMode, UserAnswers}
 import navigation.annotations.addItems.AddItemsDocument
 import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
-import org.mockito.{ArgumentCaptor, Mockito}
 import org.scalatestplus.mockito.MockitoSugar
-import pages.addItems
+import pages.addItems.AddExtraDocumentInformationPage
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, Json}
@@ -37,53 +35,38 @@ import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.twirl.api.Html
-import uk.gov.hmrc.viewmodels.NunjucksSupport
+import uk.gov.hmrc.viewmodels.{NunjucksSupport, Radios}
 
 import scala.concurrent.Future
 
-class DocumentTypeControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
+class AddExtraDocumentInformationControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
 
   def onwardRoute = Call("GET", "/foo")
 
-  private val formProvider = new DocumentTypeFormProvider()
+  private val formProvider = new AddExtraDocumentInformationFormProvider()
+  private val form         = formProvider(index)
+  private val template     = "addItems/addExtraDocumentInformation.njk"
 
-  private val documentTypeList = DocumentTypeList(
-    Seq(
-      DocumentType("955", "ATA carnet", transportDocument = true),
-      DocumentType("740", "Air waybill", transportDocument = true)
-    )
-  )
-  private val form     = formProvider(documentTypeList)
-  private val template = "addItems/documentType.njk"
-
-  private val mockRefDataConnector: ReferenceDataConnector = mock[ReferenceDataConnector]
-
-  private lazy val documentTypeRoute = controllers.addItems.documents.routes.DocumentTypeController.onPageLoad(lrn, index, documentIndex, NormalMode).url
+  lazy val addExtraDocumentInformationRoute =
+    controllers.addItems.documents.routes.AddExtraDocumentInformationController.onPageLoad(lrn, index, documentIndex, NormalMode).url
 
   override def guiceApplicationBuilder(): GuiceApplicationBuilder =
     super
       .guiceApplicationBuilder()
       .overrides(bind(classOf[Navigator]).qualifiedWith(classOf[AddItemsDocument]).toInstance(new FakeNavigator(onwardRoute)))
-      .overrides(bind[ReferenceDataConnector].toInstance(mockRefDataConnector))
 
-  override def beforeEach: Unit = {
-    super.beforeEach()
-    Mockito.reset(mockRefDataConnector)
-  }
-
-  "DocumentType Controller" - {
+  "AddExtraDocumentInformation Controller" - {
 
     "must return OK and the correct view for a GET" in {
-      dataRetrievalWithData(emptyUserAnswers)
 
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      when(mockRefDataConnector.getDocumentTypes()(any(), any())).thenReturn(Future.successful(documentTypeList))
+      dataRetrievalWithData(emptyUserAnswers)
 
-      val request                                = FakeRequest(GET, documentTypeRoute)
-      val templateCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
-      val jsonCaptor: ArgumentCaptor[JsObject]   = ArgumentCaptor.forClass(classOf[JsObject])
+      val request        = FakeRequest(GET, addExtraDocumentInformationRoute)
+      val templateCaptor = ArgumentCaptor.forClass(classOf[String])
+      val jsonCaptor     = ArgumentCaptor.forClass(classOf[JsObject])
 
       val result = route(app, request).value
 
@@ -91,18 +74,13 @@ class DocumentTypeControllerSpec extends SpecBase with MockNunjucksRendererApp w
 
       verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
-      val expectedDocumentTypeJson = Seq(
-        Json.obj("value" -> "", "text"    -> "Select"),
-        Json.obj("value" -> "955", "text" -> "(955) ATA carnet", "selected"  -> false),
-        Json.obj("value" -> "740", "text" -> "(740) Air waybill", "selected" -> false)
-      )
       val expectedJson = Json.obj(
         "form"          -> form,
+        "mode"          -> NormalMode,
+        "lrn"           -> lrn,
         "index"         -> index.display,
         "documentIndex" -> documentIndex.display,
-        "documents"     -> expectedDocumentTypeJson,
-        "mode"          -> NormalMode,
-        "lrn"           -> lrn
+        "radios"        -> Radios.yesNo(form("value"))
       )
 
       val jsonWithoutConfig = jsonCaptor.getValue - configKey
@@ -116,14 +94,13 @@ class DocumentTypeControllerSpec extends SpecBase with MockNunjucksRendererApp w
 
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
-      when(mockRefDataConnector.getDocumentTypes()(any(), any())).thenReturn(Future.successful(documentTypeList))
 
-      val userAnswers = emptyUserAnswers.set(addItems.DocumentTypePage(itemIndex, documentIndex), "955").success.value
+      val userAnswers = UserAnswers(lrn, eoriNumber).set(AddExtraDocumentInformationPage(index, documentIndex), true).success.value
       dataRetrievalWithData(userAnswers)
 
-      val request                                = FakeRequest(GET, documentTypeRoute)
-      val templateCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
-      val jsonCaptor: ArgumentCaptor[JsObject]   = ArgumentCaptor.forClass(classOf[JsObject])
+      val request        = FakeRequest(GET, addExtraDocumentInformationRoute)
+      val templateCaptor = ArgumentCaptor.forClass(classOf[String])
+      val jsonCaptor     = ArgumentCaptor.forClass(classOf[JsObject])
 
       val result = route(app, request).value
 
@@ -131,20 +108,15 @@ class DocumentTypeControllerSpec extends SpecBase with MockNunjucksRendererApp w
 
       verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
-      val filledForm = form.bind(Map("value" -> "955"))
+      val filledForm = form.bind(Map("value" -> "true"))
 
-      val expectedDocumentTypeJson = Seq(
-        Json.obj("value" -> "", "text"    -> "Select"),
-        Json.obj("value" -> "955", "text" -> "(955) ATA carnet", "selected"  -> true),
-        Json.obj("value" -> "740", "text" -> "(740) Air waybill", "selected" -> false)
-      )
       val expectedJson = Json.obj(
         "form"          -> filledForm,
+        "mode"          -> NormalMode,
+        "lrn"           -> lrn,
         "index"         -> index.display,
         "documentIndex" -> documentIndex.display,
-        "documents"     -> expectedDocumentTypeJson,
-        "lrn"           -> lrn,
-        "mode"          -> NormalMode
+        "radios"        -> Radios.yesNo(filledForm("value"))
       )
 
       val jsonWithoutConfig = jsonCaptor.getValue - configKey
@@ -155,34 +127,34 @@ class DocumentTypeControllerSpec extends SpecBase with MockNunjucksRendererApp w
     }
 
     "must redirect to the next page when valid data is submitted" in {
-      dataRetrievalWithData(emptyUserAnswers)
 
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
-      when(mockRefDataConnector.getDocumentTypes()(any(), any())).thenReturn(Future.successful(documentTypeList))
+
+      dataRetrievalWithData(emptyUserAnswers)
 
       val request =
-        FakeRequest(POST, documentTypeRoute)
-          .withFormUrlEncodedBody(("value", "955"))
+        FakeRequest(POST, addExtraDocumentInformationRoute)
+          .withFormUrlEncodedBody(("value", "true"))
 
       val result = route(app, request).value
 
       status(result) mustEqual SEE_OTHER
+
       redirectLocation(result).value mustEqual onwardRoute.url
 
     }
 
     "must return a Bad Request and errors when invalid data is submitted" in {
 
-      dataRetrievalWithData(emptyUserAnswers)
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      when(mockRefDataConnector.getDocumentTypes()(any(), any())).thenReturn(Future.successful(documentTypeList))
+      dataRetrievalWithData(emptyUserAnswers)
 
-      val request                                = FakeRequest(POST, documentTypeRoute).withFormUrlEncodedBody(("value", ""))
-      val boundForm                              = form.bind(Map("value" -> ""))
-      val templateCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
-      val jsonCaptor: ArgumentCaptor[JsObject]   = ArgumentCaptor.forClass(classOf[JsObject])
+      val request        = FakeRequest(POST, addExtraDocumentInformationRoute).withFormUrlEncodedBody(("value", ""))
+      val boundForm      = form.bind(Map("value" -> ""))
+      val templateCaptor = ArgumentCaptor.forClass(classOf[String])
+      val jsonCaptor     = ArgumentCaptor.forClass(classOf[JsObject])
 
       val result = route(app, request).value
 
@@ -192,14 +164,17 @@ class DocumentTypeControllerSpec extends SpecBase with MockNunjucksRendererApp w
 
       val expectedJson = Json.obj(
         "form"          -> boundForm,
+        "mode"          -> NormalMode,
+        "lrn"           -> lrn,
         "index"         -> index.display,
         "documentIndex" -> documentIndex.display,
-        "lrn"           -> lrn,
-        "mode"          -> NormalMode
+        "radios"        -> Radios.yesNo(boundForm("value"))
       )
 
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
+
       templateCaptor.getValue mustEqual template
-      jsonCaptor.getValue must containJson(expectedJson)
+      jsonWithoutConfig mustBe expectedJson
 
     }
 
@@ -207,7 +182,7 @@ class DocumentTypeControllerSpec extends SpecBase with MockNunjucksRendererApp w
 
       dataRetrievalNoData()
 
-      val request = FakeRequest(GET, documentTypeRoute)
+      val request = FakeRequest(GET, addExtraDocumentInformationRoute)
 
       val result = route(app, request).value
 
@@ -222,8 +197,8 @@ class DocumentTypeControllerSpec extends SpecBase with MockNunjucksRendererApp w
       dataRetrievalNoData()
 
       val request =
-        FakeRequest(POST, documentTypeRoute)
-          .withFormUrlEncodedBody(("value", "answer"))
+        FakeRequest(POST, addExtraDocumentInformationRoute)
+          .withFormUrlEncodedBody(("value", "true"))
 
       val result = route(app, request).value
 

--- a/test/controllers/addItems/documents/ConfirmRemoveDocumentControllerSpec.scala
+++ b/test/controllers/addItems/documents/ConfirmRemoveDocumentControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.addItems
+package controllers.addItems.documents
 
 import base.{MockNunjucksRendererApp, SpecBase}
 import controllers.{routes => mainRoutes}

--- a/test/controllers/addItems/documents/DocumentCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/addItems/documents/DocumentCheckYourAnswersControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.addItems.packagesInformation
+package controllers.addItems.documents
 
 import base.{MockNunjucksRendererApp, SpecBase}
 import matchers.JsonMatchers
@@ -32,14 +32,14 @@ import uk.gov.hmrc.viewmodels.NunjucksSupport
 
 import scala.concurrent.Future
 
-class PackageCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
+class DocumentCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
 
   def onwardRoute: Call = Call("GET", "/foo")
 
-  lazy val packageCyaRoute: String =
-    routes.PackageCheckYourAnswersController.onPageLoad(lrn, itemIndex, packageIndex, NormalMode).url
+  lazy val documentCyaRoute: String =
+    routes.DocumentCheckYourAnswersController.onPageLoad(lrn, itemIndex, documentIndex, NormalMode).url
 
-  "PackageCheckYourAnswersController" - {
+  "DocumentCheckYourAnswersController" - {
 
     "must return OK and the correct view for a GET" in {
 
@@ -48,7 +48,7 @@ class PackageCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRe
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val request                                = FakeRequest(GET, packageCyaRoute)
+      val request                                = FakeRequest(GET, documentCyaRoute)
       val templateCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor: ArgumentCaptor[JsObject]   = ArgumentCaptor.forClass(classOf[JsObject])
 
@@ -59,12 +59,12 @@ class PackageCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRe
       verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
       val expectedJson = Json.obj(
-        "nextPageUrl" -> routes.AddAnotherPackageController.onPageLoad(lrn, itemIndex, NormalMode).url
+        "nextPageUrl" -> routes.AddAnotherDocumentController.onPageLoad(lrn, itemIndex, NormalMode).url
       )
 
       val jsonWithoutConfig = jsonCaptor.getValue - configKey - "section"
 
-      templateCaptor.getValue mustEqual "addItems/packageCheckYourAnswers.njk"
+      templateCaptor.getValue mustEqual "addItems/documentCheckYourAnswers.njk"
       jsonWithoutConfig mustBe expectedJson
     }
   }

--- a/test/controllers/addItems/documents/DocumentCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/addItems/documents/DocumentCheckYourAnswersControllerSpec.scala
@@ -17,12 +17,15 @@
 package controllers.addItems.documents
 
 import base.{MockNunjucksRendererApp, SpecBase}
+import connectors.ReferenceDataConnector
 import matchers.JsonMatchers
-import models.NormalMode
+import models.{DocumentTypeList, NormalMode}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.Call
 import play.api.test.FakeRequest
@@ -39,6 +42,13 @@ class DocumentCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksR
   lazy val documentCyaRoute: String =
     routes.DocumentCheckYourAnswersController.onPageLoad(lrn, itemIndex, documentIndex, NormalMode).url
 
+  private val mockRefDataConnector: ReferenceDataConnector = mock[ReferenceDataConnector]
+
+  override def guiceApplicationBuilder(): GuiceApplicationBuilder =
+    super
+      .guiceApplicationBuilder()
+      .overrides(bind(classOf[ReferenceDataConnector]).toInstance(mockRefDataConnector))
+
   "DocumentCheckYourAnswersController" - {
 
     "must return OK and the correct view for a GET" in {
@@ -47,6 +57,9 @@ class DocumentCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksR
 
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
+
+      when(mockRefDataConnector.getDocumentTypes()(any(), any()))
+        .thenReturn(Future.successful(DocumentTypeList(Nil)))
 
       val request                                = FakeRequest(GET, documentCyaRoute)
       val templateCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])

--- a/test/controllers/addItems/documents/DocumentExtraInformationControllerSpec.scala
+++ b/test/controllers/addItems/documents/DocumentExtraInformationControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.addItems
+package controllers.addItems.documents
 
 import base.{MockNunjucksRendererApp, SpecBase}
 import controllers.{routes => mainRoutes}

--- a/test/controllers/addItems/documents/DocumentReferenceControllerSpec.scala
+++ b/test/controllers/addItems/documents/DocumentReferenceControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.addItems
+package controllers.addItems.documents
 
 import base.{MockNunjucksRendererApp, SpecBase}
 import controllers.{routes => mainRoutes}

--- a/test/controllers/addItems/documents/TIRCarnetReferenceControllerSpec.scala
+++ b/test/controllers/addItems/documents/TIRCarnetReferenceControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.addItems
+package controllers.addItems.documents
 
 import base.{MockNunjucksRendererApp, SpecBase}
 import commonTestUtils.UserAnswersSpecHelper

--- a/test/controllers/addItems/packagesInformation/HowManyPackagesControllerSpec.scala
+++ b/test/controllers/addItems/packagesInformation/HowManyPackagesControllerSpec.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package controllers.addItems
+package controllers.addItems.packagesInformation
 
 import base.{MockNunjucksRendererApp, SpecBase}
 import controllers.{routes => mainRoutes}
-import forms.addItems.TotalPiecesFormProvider
+import forms.addItems.HowManyPackagesFormProvider
 import matchers.JsonMatchers
 import models.NormalMode
 import navigation.annotations.addItems.AddItemsPackagesInfo
@@ -27,7 +27,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
-import pages.addItems.TotalPiecesPage
+import pages.addItems.HowManyPackagesPage
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, Json}
@@ -39,30 +39,30 @@ import uk.gov.hmrc.viewmodels.NunjucksSupport
 
 import scala.concurrent.Future
 
-class TotalPiecesControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
+class HowManyPackagesControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
 
-  val formProvider = new TotalPiecesFormProvider()
+  val formProvider = new HowManyPackagesFormProvider()
   val form         = formProvider(index.display)
 
   def onwardRoute = Call("GET", "/foo")
 
   val validAnswer = 1
 
-  lazy val totalPiecesRoute = controllers.addItems.packagesInformation.routes.TotalPiecesController.onPageLoad(lrn, index, index, NormalMode).url
+  lazy val howManyPackagesRoute = controllers.addItems.packagesInformation.routes.HowManyPackagesController.onPageLoad(lrn, index, index, NormalMode).url
 
   override def guiceApplicationBuilder(): GuiceApplicationBuilder =
     super
       .guiceApplicationBuilder()
       .overrides(bind(classOf[Navigator]).qualifiedWith(classOf[AddItemsPackagesInfo]).toInstance(new FakeNavigator(onwardRoute)))
 
-  "TotalPieces Controller" - {
+  "HowManyPackages Controller" - {
 
     "must return OK and the correct view for a GET" in {
       dataRetrievalWithData(emptyUserAnswers)
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val request        = FakeRequest(GET, totalPiecesRoute)
+      val request        = FakeRequest(GET, howManyPackagesRoute)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor     = ArgumentCaptor.forClass(classOf[JsObject])
 
@@ -81,7 +81,7 @@ class TotalPiecesControllerSpec extends SpecBase with MockNunjucksRendererApp wi
         "packageIndex" -> packageIndex.display
       )
 
-      templateCaptor.getValue mustEqual "addItems/totalPieces.njk"
+      templateCaptor.getValue mustEqual "addItems/howManyPackages.njk"
       jsonCaptor.getValue must containJson(expectedJson)
     }
 
@@ -90,9 +90,9 @@ class TotalPiecesControllerSpec extends SpecBase with MockNunjucksRendererApp wi
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val userAnswers = emptyUserAnswers.set(TotalPiecesPage(index, index), validAnswer).success.value
+      val userAnswers = emptyUserAnswers.set(HowManyPackagesPage(index, index), validAnswer).success.value
       dataRetrievalWithData(userAnswers)
-      val request        = FakeRequest(GET, totalPiecesRoute)
+      val request        = FakeRequest(GET, howManyPackagesRoute)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor     = ArgumentCaptor.forClass(classOf[JsObject])
 
@@ -113,17 +113,16 @@ class TotalPiecesControllerSpec extends SpecBase with MockNunjucksRendererApp wi
         "packageIndex" -> packageIndex.display
       )
 
-      templateCaptor.getValue mustEqual "addItems/totalPieces.njk"
+      templateCaptor.getValue mustEqual "addItems/howManyPackages.njk"
       jsonCaptor.getValue must containJson(expectedJson)
     }
 
     "must redirect to the next page when valid data is submitted" in {
-
       dataRetrievalWithData(emptyUserAnswers)
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
 
       val request =
-        FakeRequest(POST, totalPiecesRoute)
+        FakeRequest(POST, howManyPackagesRoute)
           .withFormUrlEncodedBody(("value", validAnswer.toString))
 
       val result = route(app, request).value
@@ -131,6 +130,7 @@ class TotalPiecesControllerSpec extends SpecBase with MockNunjucksRendererApp wi
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
+
     }
 
     "must return a Bad Request and errors when invalid data is submitted" in {
@@ -138,7 +138,7 @@ class TotalPiecesControllerSpec extends SpecBase with MockNunjucksRendererApp wi
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val request        = FakeRequest(POST, totalPiecesRoute).withFormUrlEncodedBody(("value", "invalid value"))
+      val request        = FakeRequest(POST, howManyPackagesRoute).withFormUrlEncodedBody(("value", "invalid value"))
       val boundForm      = form.bind(Map("value" -> "invalid value"))
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor     = ArgumentCaptor.forClass(classOf[JsObject])
@@ -158,14 +158,15 @@ class TotalPiecesControllerSpec extends SpecBase with MockNunjucksRendererApp wi
         "packageIndex" -> packageIndex.display
       )
 
-      templateCaptor.getValue mustEqual "addItems/totalPieces.njk"
+      templateCaptor.getValue mustEqual "addItems/howManyPackages.njk"
       jsonCaptor.getValue must containJson(expectedJson)
     }
 
     "must redirect to Session Expired for a GET if no existing data is found" in {
+
       dataRetrievalNoData()
 
-      val request = FakeRequest(GET, totalPiecesRoute)
+      val request = FakeRequest(GET, howManyPackagesRoute)
 
       val result = route(app, request).value
 
@@ -174,10 +175,11 @@ class TotalPiecesControllerSpec extends SpecBase with MockNunjucksRendererApp wi
     }
 
     "must redirect to Session Expired for a POST if no existing data is found" in {
+
       dataRetrievalNoData()
 
       val request =
-        FakeRequest(POST, totalPiecesRoute)
+        FakeRequest(POST, howManyPackagesRoute)
           .withFormUrlEncodedBody(("value", validAnswer.toString))
 
       val result = route(app, request).value

--- a/test/controllers/addItems/packagesInformation/PackageCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/addItems/packagesInformation/PackageCheckYourAnswersControllerSpec.scala
@@ -32,14 +32,14 @@ import uk.gov.hmrc.viewmodels.NunjucksSupport
 
 import scala.concurrent.Future
 
-class PackagesCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
+class PackageCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
 
   def onwardRoute: Call = Call("GET", "/foo")
 
   lazy val packagesCyaRoute: String =
-    routes.PackagesCheckYourAnswersController.onPageLoad(lrn, itemIndex, packageIndex, NormalMode).url
+    routes.PackageCheckYourAnswersController.onPageLoad(lrn, itemIndex, packageIndex, NormalMode).url
 
-  "PackagesCheckYourAnswersController" - {
+  "PackageCheckYourAnswersController" - {
 
     "must return OK and the correct view for a GET" in {
 
@@ -64,7 +64,7 @@ class PackagesCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksR
 
       val jsonWithoutConfig = jsonCaptor.getValue - configKey - "section"
 
-      templateCaptor.getValue mustEqual "addItems/packagesCheckYourAnswers.njk"
+      templateCaptor.getValue mustEqual "addItems/packageCheckYourAnswers.njk"
       jsonWithoutConfig mustBe expectedJson
     }
   }

--- a/test/controllers/addItems/packagesInformation/PackageTypeControllerSpec.scala
+++ b/test/controllers/addItems/packagesInformation/PackageTypeControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.addItems
+package controllers.addItems.packagesInformation
 
 import base.{MockNunjucksRendererApp, SpecBase}
 import connectors.ReferenceDataConnector

--- a/test/controllers/addItems/packagesInformation/PackagesCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/addItems/packagesInformation/PackagesCheckYourAnswersControllerSpec.scala
@@ -62,7 +62,7 @@ class PackagesCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksR
         "nextPageUrl" -> routes.AddAnotherPackageController.onPageLoad(lrn, itemIndex, NormalMode).url
       )
 
-      val jsonWithoutConfig = jsonCaptor.getValue - configKey - "sections"
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey - "section"
 
       templateCaptor.getValue mustEqual "addItems/packagesCheckYourAnswers.njk"
       jsonWithoutConfig mustBe expectedJson

--- a/test/controllers/addItems/packagesInformation/PackagesCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/addItems/packagesInformation/PackagesCheckYourAnswersControllerSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.addItems.packagesInformation
+
+import base.{MockNunjucksRendererApp, SpecBase}
+import matchers.JsonMatchers
+import models.NormalMode
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{times, verify, when}
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.libs.json.{JsObject, Json}
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import play.twirl.api.Html
+import uk.gov.hmrc.viewmodels.NunjucksSupport
+
+import scala.concurrent.Future
+
+class PackagesCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
+
+  def onwardRoute: Call = Call("GET", "/foo")
+
+  lazy val packagesCyaRoute: String =
+    routes.PackagesCheckYourAnswersController.onPageLoad(lrn, itemIndex, packageIndex, NormalMode).url
+
+  "PackagesCheckYourAnswersController" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      dataRetrievalWithData(emptyUserAnswers)
+
+      when(mockRenderer.render(any(), any())(any()))
+        .thenReturn(Future.successful(Html("")))
+
+      val request                                = FakeRequest(GET, packagesCyaRoute)
+      val templateCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
+      val jsonCaptor: ArgumentCaptor[JsObject]   = ArgumentCaptor.forClass(classOf[JsObject])
+
+      val result = route(app, request).value
+
+      status(result) mustEqual OK
+
+      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
+
+      val expectedJson = Json.obj(
+        "nextPageUrl" -> routes.AddAnotherPackageController.onPageLoad(lrn, itemIndex, NormalMode).url
+      )
+
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey - "sections"
+
+      templateCaptor.getValue mustEqual "addItems/packagesCheckYourAnswers.njk"
+      jsonWithoutConfig mustBe expectedJson
+    }
+  }
+}

--- a/test/controllers/addItems/packagesInformation/RemovePackageControllerSpec.scala
+++ b/test/controllers/addItems/packagesInformation/RemovePackageControllerSpec.scala
@@ -14,20 +14,19 @@
  * limitations under the License.
  */
 
-package controllers.addItems
+package controllers.addItems.packagesInformation
 
 import base.{MockNunjucksRendererApp, SpecBase}
 import controllers.{routes => mainRoutes}
-import forms.addItems.AddAnotherPackageFormProvider
+import forms.addItems.RemovePackageFormProvider
 import matchers.JsonMatchers
-import models.{NormalMode, UserAnswers}
+import models.NormalMode
 import navigation.annotations.addItems.AddItemsPackagesInfo
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
-import pages.addItems.AddAnotherPackagePage
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, Json}
@@ -39,28 +38,29 @@ import uk.gov.hmrc.viewmodels.{NunjucksSupport, Radios}
 
 import scala.concurrent.Future
 
-class AddAnotherPackageControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
+class RemovePackageControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
 
   def onwardRoute = Call("GET", "/foo")
 
-  val formProvider = new AddAnotherPackageFormProvider()
-  val form         = formProvider()
+  private val formProvider = new RemovePackageFormProvider()
+  private val form         = formProvider(index.display)
+  private val template     = "addItems/removePackage.njk"
+
+  lazy val removePackageRoute = controllers.addItems.packagesInformation.routes.RemovePackageController.onPageLoad(lrn, index, index, NormalMode).url
 
   override def guiceApplicationBuilder(): GuiceApplicationBuilder =
     super
       .guiceApplicationBuilder()
       .overrides(bind(classOf[Navigator]).qualifiedWith(classOf[AddItemsPackagesInfo]).toInstance(new FakeNavigator(onwardRoute)))
 
-  lazy val addAnotherPackageRoute = controllers.addItems.packagesInformation.routes.AddAnotherPackageController.onPageLoad(lrn, index, NormalMode).url
-
-  "AddAnotherPackage Controller" - {
+  "RemovePackage Controller" - {
 
     "must return OK and the correct view for a GET" in {
       dataRetrievalWithData(emptyUserAnswers)
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val request        = FakeRequest(GET, addAnotherPackageRoute)
+      val request        = FakeRequest(GET, removePackageRoute)
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor     = ArgumentCaptor.forClass(classOf[JsObject])
 
@@ -71,56 +71,27 @@ class AddAnotherPackageControllerSpec extends SpecBase with MockNunjucksRenderer
       verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
       val expectedJson = Json.obj(
-        "form"      -> form,
-        "mode"      -> NormalMode,
-        "lrn"       -> lrn,
-        "itemIndex" -> itemIndex.display,
-        "radios"    -> Radios.yesNo(form("value"))
+        "form"         -> form,
+        "itemIndex"    -> itemIndex.display,
+        "packageIndex" -> packageIndex.display,
+        "mode"         -> NormalMode,
+        "lrn"          -> lrn,
+        "radios"       -> Radios.yesNo(form("value"))
       )
 
-      templateCaptor.getValue mustEqual "addItems/addAnotherPackage.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
 
-    }
-
-    "must populate the view correctly on a GET when the question has previously been answered" in {
-
-      val userAnswers = UserAnswers(lrn, eoriNumber).set(AddAnotherPackagePage(index), true).success.value
-      dataRetrievalWithData(userAnswers)
-      when(mockRenderer.render(any(), any())(any()))
-        .thenReturn(Future.successful(Html("")))
-
-      val request        = FakeRequest(GET, addAnotherPackageRoute)
-      val templateCaptor = ArgumentCaptor.forClass(classOf[String])
-      val jsonCaptor     = ArgumentCaptor.forClass(classOf[JsObject])
-
-      val result = route(app, request).value
-
-      status(result) mustEqual OK
-
-      verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
-
-      val filledForm = form.bind(Map("value" -> "true"))
-
-      val expectedJson = Json.obj(
-        "form"      -> filledForm,
-        "mode"      -> NormalMode,
-        "lrn"       -> lrn,
-        "itemIndex" -> itemIndex.display,
-        "radios"    -> Radios.yesNo(filledForm("value"))
-      )
-
-      templateCaptor.getValue mustEqual "addItems/addAnotherPackage.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
-
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
     }
 
     "must redirect to the next page when valid data is submitted" in {
       dataRetrievalWithData(emptyUserAnswers)
+
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
 
       val request =
-        FakeRequest(POST, addAnotherPackageRoute)
+        FakeRequest(POST, removePackageRoute)
           .withFormUrlEncodedBody(("value", "true"))
 
       val result = route(app, request).value
@@ -128,7 +99,6 @@ class AddAnotherPackageControllerSpec extends SpecBase with MockNunjucksRenderer
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
-
     }
 
     "must return a Bad Request and errors when invalid data is submitted" in {
@@ -136,7 +106,7 @@ class AddAnotherPackageControllerSpec extends SpecBase with MockNunjucksRenderer
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val request        = FakeRequest(POST, addAnotherPackageRoute).withFormUrlEncodedBody(("value", ""))
+      val request        = FakeRequest(POST, removePackageRoute).withFormUrlEncodedBody(("value", ""))
       val boundForm      = form.bind(Map("value" -> ""))
       val templateCaptor = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor     = ArgumentCaptor.forClass(classOf[JsObject])
@@ -148,29 +118,31 @@ class AddAnotherPackageControllerSpec extends SpecBase with MockNunjucksRenderer
       verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
       val expectedJson = Json.obj(
-        "form"      -> boundForm,
-        "mode"      -> NormalMode,
-        "lrn"       -> lrn,
-        "itemIndex" -> itemIndex.display,
-        "radios"    -> Radios.yesNo(boundForm("value"))
+        "form"         -> boundForm,
+        "itemIndex"    -> itemIndex.display,
+        "packageIndex" -> packageIndex.display,
+        "mode"         -> NormalMode,
+        "lrn"          -> lrn,
+        "radios"       -> Radios.yesNo(boundForm("value"))
       )
 
-      templateCaptor.getValue mustEqual "addItems/addAnotherPackage.njk"
-      jsonCaptor.getValue must containJson(expectedJson)
+      val jsonWithoutConfig = jsonCaptor.getValue - configKey
 
+      templateCaptor.getValue mustEqual template
+      jsonWithoutConfig mustBe expectedJson
     }
 
     "must redirect to Session Expired for a GET if no existing data is found" in {
 
       dataRetrievalNoData()
-      val request = FakeRequest(GET, addAnotherPackageRoute)
+
+      val request = FakeRequest(GET, removePackageRoute)
 
       val result = route(app, request).value
 
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual mainRoutes.SessionExpiredController.onPageLoad().url
-
     }
 
     "must redirect to Session Expired for a POST if no existing data is found" in {
@@ -178,7 +150,7 @@ class AddAnotherPackageControllerSpec extends SpecBase with MockNunjucksRenderer
       dataRetrievalNoData()
 
       val request =
-        FakeRequest(POST, addAnotherPackageRoute)
+        FakeRequest(POST, removePackageRoute)
           .withFormUrlEncodedBody(("value", "true"))
 
       val result = route(app, request).value
@@ -186,7 +158,6 @@ class AddAnotherPackageControllerSpec extends SpecBase with MockNunjucksRenderer
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual mainRoutes.SessionExpiredController.onPageLoad().url
-
     }
   }
 }

--- a/test/controllers/addItems/previousReferences/ReferenceCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/addItems/previousReferences/ReferenceCheckYourAnswersControllerSpec.scala
@@ -17,12 +17,15 @@
 package controllers.addItems.previousReferences
 
 import base.{MockNunjucksRendererApp, SpecBase}
+import connectors.ReferenceDataConnector
 import matchers.JsonMatchers
-import models.NormalMode
+import models.{NormalMode, PreviousReferencesDocumentTypeList}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.Call
 import play.api.test.FakeRequest
@@ -39,6 +42,13 @@ class ReferenceCheckYourAnswersControllerSpec extends SpecBase with MockNunjucks
   lazy val referenceCyaRoute: String =
     routes.ReferenceCheckYourAnswersController.onPageLoad(lrn, itemIndex, referenceIndex, NormalMode).url
 
+  private val mockRefDataConnector: ReferenceDataConnector = mock[ReferenceDataConnector]
+
+  override def guiceApplicationBuilder(): GuiceApplicationBuilder =
+    super
+      .guiceApplicationBuilder()
+      .overrides(bind(classOf[ReferenceDataConnector]).toInstance(mockRefDataConnector))
+
   "ReferenceCheckYourAnswersController" - {
 
     "must return OK and the correct view for a GET" in {
@@ -47,6 +57,9 @@ class ReferenceCheckYourAnswersControllerSpec extends SpecBase with MockNunjucks
 
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
+
+      when(mockRefDataConnector.getPreviousReferencesDocumentTypes()(any(), any()))
+        .thenReturn(Future.successful(PreviousReferencesDocumentTypeList(Nil)))
 
       val request                                = FakeRequest(GET, referenceCyaRoute)
       val templateCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])

--- a/test/controllers/addItems/previousReferences/ReferenceCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/addItems/previousReferences/ReferenceCheckYourAnswersControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.addItems.packagesInformation
+package controllers.addItems.previousReferences
 
 import base.{MockNunjucksRendererApp, SpecBase}
 import matchers.JsonMatchers
@@ -32,14 +32,14 @@ import uk.gov.hmrc.viewmodels.NunjucksSupport
 
 import scala.concurrent.Future
 
-class PackageCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
+class ReferenceCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
 
   def onwardRoute: Call = Call("GET", "/foo")
 
-  lazy val packageCyaRoute: String =
-    routes.PackageCheckYourAnswersController.onPageLoad(lrn, itemIndex, packageIndex, NormalMode).url
+  lazy val referenceCyaRoute: String =
+    routes.ReferenceCheckYourAnswersController.onPageLoad(lrn, itemIndex, referenceIndex, NormalMode).url
 
-  "PackageCheckYourAnswersController" - {
+  "ReferenceCheckYourAnswersController" - {
 
     "must return OK and the correct view for a GET" in {
 
@@ -48,7 +48,7 @@ class PackageCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRe
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val request                                = FakeRequest(GET, packageCyaRoute)
+      val request                                = FakeRequest(GET, referenceCyaRoute)
       val templateCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor: ArgumentCaptor[JsObject]   = ArgumentCaptor.forClass(classOf[JsObject])
 
@@ -59,12 +59,12 @@ class PackageCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRe
       verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
       val expectedJson = Json.obj(
-        "nextPageUrl" -> routes.AddAnotherPackageController.onPageLoad(lrn, itemIndex, NormalMode).url
+        "nextPageUrl" -> routes.AddAnotherPreviousAdministrativeReferenceController.onPageLoad(lrn, itemIndex, NormalMode).url
       )
 
       val jsonWithoutConfig = jsonCaptor.getValue - configKey - "section"
 
-      templateCaptor.getValue mustEqual "addItems/packageCheckYourAnswers.njk"
+      templateCaptor.getValue mustEqual "addItems/referenceCheckYourAnswers.njk"
       jsonWithoutConfig mustBe expectedJson
     }
   }

--- a/test/controllers/addItems/specialMentions/SpecialMentionCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/addItems/specialMentions/SpecialMentionCheckYourAnswersControllerSpec.scala
@@ -17,12 +17,15 @@
 package controllers.addItems.specialMentions
 
 import base.{MockNunjucksRendererApp, SpecBase}
+import connectors.ReferenceDataConnector
 import matchers.JsonMatchers
-import models.NormalMode
+import models.{NormalMode, SpecialMentionList}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.Call
 import play.api.test.FakeRequest
@@ -39,6 +42,13 @@ class SpecialMentionCheckYourAnswersControllerSpec extends SpecBase with MockNun
   lazy val specialMentionCyaRoute: String =
     routes.SpecialMentionCheckYourAnswersController.onPageLoad(lrn, itemIndex, referenceIndex, NormalMode).url
 
+  private val mockRefDataConnector: ReferenceDataConnector = mock[ReferenceDataConnector]
+
+  override def guiceApplicationBuilder(): GuiceApplicationBuilder =
+    super
+      .guiceApplicationBuilder()
+      .overrides(bind(classOf[ReferenceDataConnector]).toInstance(mockRefDataConnector))
+
   "SpecialMentionCheckYourAnswersController" - {
 
     "must return OK and the correct view for a GET" in {
@@ -47,6 +57,9 @@ class SpecialMentionCheckYourAnswersControllerSpec extends SpecBase with MockNun
 
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
+
+      when(mockRefDataConnector.getSpecialMention()(any(), any()))
+        .thenReturn(Future.successful(SpecialMentionList(Nil)))
 
       val request                                = FakeRequest(GET, specialMentionCyaRoute)
       val templateCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])

--- a/test/controllers/addItems/specialMentions/SpecialMentionCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/addItems/specialMentions/SpecialMentionCheckYourAnswersControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.addItems.packagesInformation
+package controllers.addItems.specialMentions
 
 import base.{MockNunjucksRendererApp, SpecBase}
 import matchers.JsonMatchers
@@ -32,14 +32,14 @@ import uk.gov.hmrc.viewmodels.NunjucksSupport
 
 import scala.concurrent.Future
 
-class PackageCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
+class SpecialMentionCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRendererApp with MockitoSugar with NunjucksSupport with JsonMatchers {
 
   def onwardRoute: Call = Call("GET", "/foo")
 
-  lazy val packageCyaRoute: String =
-    routes.PackageCheckYourAnswersController.onPageLoad(lrn, itemIndex, packageIndex, NormalMode).url
+  lazy val specialMentionCyaRoute: String =
+    routes.SpecialMentionCheckYourAnswersController.onPageLoad(lrn, itemIndex, referenceIndex, NormalMode).url
 
-  "PackageCheckYourAnswersController" - {
+  "SpecialMentionCheckYourAnswersController" - {
 
     "must return OK and the correct view for a GET" in {
 
@@ -48,7 +48,7 @@ class PackageCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRe
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
 
-      val request                                = FakeRequest(GET, packageCyaRoute)
+      val request                                = FakeRequest(GET, specialMentionCyaRoute)
       val templateCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
       val jsonCaptor: ArgumentCaptor[JsObject]   = ArgumentCaptor.forClass(classOf[JsObject])
 
@@ -59,12 +59,12 @@ class PackageCheckYourAnswersControllerSpec extends SpecBase with MockNunjucksRe
       verify(mockRenderer, times(1)).render(templateCaptor.capture(), jsonCaptor.capture())(any())
 
       val expectedJson = Json.obj(
-        "nextPageUrl" -> routes.AddAnotherPackageController.onPageLoad(lrn, itemIndex, NormalMode).url
+        "nextPageUrl" -> routes.AddAnotherSpecialMentionController.onPageLoad(lrn, itemIndex, NormalMode).url
       )
 
       val jsonWithoutConfig = jsonCaptor.getValue - configKey - "section"
 
-      templateCaptor.getValue mustEqual "addItems/packageCheckYourAnswers.njk"
+      templateCaptor.getValue mustEqual "addItems/specialMentions/specialMentionCheckYourAnswers.njk"
       jsonWithoutConfig mustBe expectedJson
     }
   }

--- a/test/navigation/AddItemsAdminReferenceCheckModeNavigatorSpec.scala
+++ b/test/navigation/AddItemsAdminReferenceCheckModeNavigatorSpec.scala
@@ -41,11 +41,11 @@ class AddItemsAdminReferenceCheckModeNavigatorSpec extends SpecBase with ScalaCh
       forAll(arbitrary[UserAnswers]) {
         answers =>
           val updatedAnswers = answers
-            .set(AddAdministrativeReferencePage(index), false).success.value
+            .set(AddAdministrativeReferencePage(itemIndex), false).success.value
             .set(AddSecurityDetailsPage, false).success.value
           navigator
-            .nextPage(AddAdministrativeReferencePage(index), CheckMode, updatedAnswers)
-            .mustBe(routes.ItemsCheckYourAnswersController.onPageLoad(updatedAnswers.lrn, index))
+            .nextPage(AddAdministrativeReferencePage(itemIndex), CheckMode, updatedAnswers)
+            .mustBe(routes.ItemsCheckYourAnswersController.onPageLoad(updatedAnswers.lrn, itemIndex))
       }
     }
 
@@ -53,8 +53,8 @@ class AddItemsAdminReferenceCheckModeNavigatorSpec extends SpecBase with ScalaCh
       forAll(arbitrary[UserAnswers]) {
         answers =>
           navigator
-            .nextPage(ReferenceTypePage(index, referenceIndex), CheckMode, answers)
-            .mustBe(previousReferenceRoutes.PreviousReferenceController.onPageLoad(answers.lrn, index, referenceIndex, CheckMode))
+            .nextPage(ReferenceTypePage(itemIndex, referenceIndex), CheckMode, answers)
+            .mustBe(previousReferenceRoutes.PreviousReferenceController.onPageLoad(answers.lrn, itemIndex, referenceIndex, CheckMode))
       }
     }
 
@@ -62,41 +62,41 @@ class AddItemsAdminReferenceCheckModeNavigatorSpec extends SpecBase with ScalaCh
       forAll(arbitrary[UserAnswers]) {
         answers =>
           navigator
-            .nextPage(PreviousReferencePage(index, referenceIndex), CheckMode, answers)
-            .mustBe(previousReferenceRoutes.AddExtraInformationController.onPageLoad(answers.lrn, index, referenceIndex, CheckMode))
+            .nextPage(PreviousReferencePage(itemIndex, referenceIndex), CheckMode, answers)
+            .mustBe(previousReferenceRoutes.AddExtraInformationController.onPageLoad(answers.lrn, itemIndex, referenceIndex, CheckMode))
       }
     }
 
     "must go from 'add extra information' page to 'extra information' page on selecting 'Yes'" in {
       forAll(arbitrary[UserAnswers]) {
         answers =>
-          val updatedAnswer = answers.set(AddExtraInformationPage(index, referenceIndex), true).success.value
+          val updatedAnswer = answers.set(AddExtraInformationPage(itemIndex, referenceIndex), true).success.value
 
           navigator
-            .nextPage(AddExtraInformationPage(index, referenceIndex), CheckMode, updatedAnswer)
-            .mustBe(previousReferenceRoutes.ExtraInformationController.onPageLoad(answers.lrn, index, referenceIndex, CheckMode))
+            .nextPage(AddExtraInformationPage(itemIndex, referenceIndex), CheckMode, updatedAnswer)
+            .mustBe(previousReferenceRoutes.ExtraInformationController.onPageLoad(answers.lrn, itemIndex, referenceIndex, CheckMode))
       }
     }
 
-    "must go from 'add extra information' page to 'Add another reference' page on selecting 'No'" in {
+    "must go from 'add extra information' page to 'CYA' page on selecting 'No'" in {
       forAll(arbitrary[UserAnswers]) {
         answers =>
-          val updatedAnswer = answers.set(AddExtraInformationPage(index, referenceIndex), false).success.value
+          val updatedAnswer = answers.set(AddExtraInformationPage(itemIndex, referenceIndex), false).success.value
 
           navigator
-            .nextPage(AddExtraInformationPage(index, referenceIndex), CheckMode, updatedAnswer)
-            .mustBe(previousReferenceRoutes.AddAnotherPreviousAdministrativeReferenceController.onPageLoad(answers.lrn, index, CheckMode))
+            .nextPage(AddExtraInformationPage(itemIndex, referenceIndex), CheckMode, updatedAnswer)
+            .mustBe(previousReferenceRoutes.ReferenceCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, referenceIndex, CheckMode))
       }
     }
 
-    "must go from 'extra information' page to 'Add another reference' page" in {
+    "must go from 'extra information' page to 'CYA' page" in {
       forAll(arbitrary[UserAnswers]) {
         answers =>
-          val updatedAnswer = answers.set(ExtraInformationPage(index, referenceIndex), "text").success.value
+          val updatedAnswer = answers.set(ExtraInformationPage(itemIndex, referenceIndex), "text").success.value
 
           navigator
-            .nextPage(ExtraInformationPage(index, referenceIndex), CheckMode, updatedAnswer)
-            .mustBe(previousReferenceRoutes.AddAnotherPreviousAdministrativeReferenceController.onPageLoad(answers.lrn, index, CheckMode))
+            .nextPage(ExtraInformationPage(itemIndex, referenceIndex), CheckMode, updatedAnswer)
+            .mustBe(previousReferenceRoutes.ReferenceCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, referenceIndex, CheckMode))
       }
     }
 
@@ -104,12 +104,12 @@ class AddItemsAdminReferenceCheckModeNavigatorSpec extends SpecBase with ScalaCh
       forAll(arbitrary[UserAnswers]) {
         answers =>
           val updatedAnswer = answers
-            .remove(PreviousReferencesQuery(index)).success.value
-            .set(AddAnotherPreviousAdministrativeReferencePage(index), true).success.value
+            .remove(PreviousReferencesQuery(itemIndex)).success.value
+            .set(AddAnotherPreviousAdministrativeReferencePage(itemIndex), true).success.value
 
           navigator
-            .nextPage(AddAnotherPreviousAdministrativeReferencePage(index), CheckMode, updatedAnswer)
-            .mustBe(previousReferenceRoutes.ReferenceTypeController.onPageLoad(answers.lrn, index, index, CheckMode))
+            .nextPage(AddAnotherPreviousAdministrativeReferencePage(itemIndex), CheckMode, updatedAnswer)
+            .mustBe(previousReferenceRoutes.ReferenceTypeController.onPageLoad(answers.lrn, itemIndex, referenceIndex, CheckMode))
       }
     }
 
@@ -117,12 +117,12 @@ class AddItemsAdminReferenceCheckModeNavigatorSpec extends SpecBase with ScalaCh
       forAll(arbitrary[UserAnswers]) {
         answers =>
           val updatedAnswer = answers
-            .remove(PreviousReferencesQuery(index)).success.value
-            .set(AddAnotherPreviousAdministrativeReferencePage(index), false).success.value
+            .remove(PreviousReferencesQuery(itemIndex)).success.value
+            .set(AddAnotherPreviousAdministrativeReferencePage(itemIndex), false).success.value
 
           navigator
-            .nextPage(AddAnotherPreviousAdministrativeReferencePage(index), CheckMode, updatedAnswer)
-            .mustBe(routes.ItemsCheckYourAnswersController.onPageLoad(answers.lrn, index))
+            .nextPage(AddAnotherPreviousAdministrativeReferencePage(itemIndex), CheckMode, updatedAnswer)
+            .mustBe(routes.ItemsCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex))
       }
     }
 

--- a/test/navigation/AddItemsAdminReferenceNormalModeNavigatorSpec.scala
+++ b/test/navigation/AddItemsAdminReferenceNormalModeNavigatorSpec.scala
@@ -41,8 +41,8 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
       forAll(arbitrary[UserAnswers]) {
         answers =>
           navigator
-            .nextPage(ReferenceTypePage(index, referenceIndex), NormalMode, answers)
-            .mustBe(previousReferenceRoutes.PreviousReferenceController.onPageLoad(answers.lrn, index, referenceIndex, NormalMode))
+            .nextPage(ReferenceTypePage(itemIndex, referenceIndex), NormalMode, answers)
+            .mustBe(previousReferenceRoutes.PreviousReferenceController.onPageLoad(answers.lrn, itemIndex, referenceIndex, NormalMode))
       }
     }
 
@@ -50,41 +50,41 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
       forAll(arbitrary[UserAnswers]) {
         answers =>
           navigator
-            .nextPage(PreviousReferencePage(index, referenceIndex), NormalMode, answers)
-            .mustBe(previousReferenceRoutes.AddExtraInformationController.onPageLoad(answers.lrn, index, referenceIndex, NormalMode))
+            .nextPage(PreviousReferencePage(itemIndex, referenceIndex), NormalMode, answers)
+            .mustBe(previousReferenceRoutes.AddExtraInformationController.onPageLoad(answers.lrn, itemIndex, referenceIndex, NormalMode))
       }
     }
 
     "must go from 'add extra information' page to 'extra information' page on selecting 'Yes'" in {
       forAll(arbitrary[UserAnswers]) {
         answers =>
-          val updatedAnswer = answers.set(AddExtraInformationPage(index, referenceIndex), true).success.value
+          val updatedAnswer = answers.set(AddExtraInformationPage(itemIndex, referenceIndex), true).success.value
 
           navigator
-            .nextPage(AddExtraInformationPage(index, referenceIndex), NormalMode, updatedAnswer)
-            .mustBe(previousReferenceRoutes.ExtraInformationController.onPageLoad(answers.lrn, index, referenceIndex, NormalMode))
+            .nextPage(AddExtraInformationPage(itemIndex, referenceIndex), NormalMode, updatedAnswer)
+            .mustBe(previousReferenceRoutes.ExtraInformationController.onPageLoad(answers.lrn, itemIndex, referenceIndex, NormalMode))
       }
     }
 
-    "must go from 'add extra information' page to 'Add another reference' page on selecting 'No'" in {
+    "must go from 'add extra information' page to 'CYA' page on selecting 'No'" in {
       forAll(arbitrary[UserAnswers]) {
         answers =>
-          val updatedAnswer = answers.set(AddExtraInformationPage(index, referenceIndex), false).success.value
+          val updatedAnswer = answers.set(AddExtraInformationPage(itemIndex, referenceIndex), false).success.value
 
           navigator
-            .nextPage(AddExtraInformationPage(index, referenceIndex), NormalMode, updatedAnswer)
-            .mustBe(previousReferenceRoutes.AddAnotherPreviousAdministrativeReferenceController.onPageLoad(answers.lrn, index, NormalMode))
+            .nextPage(AddExtraInformationPage(itemIndex, referenceIndex), NormalMode, updatedAnswer)
+            .mustBe(previousReferenceRoutes.ReferenceCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, referenceIndex, NormalMode))
       }
     }
 
-    "must go from 'extra information' page to 'Add another reference' page" in {
+    "must go from 'extra information' page to 'CYA' page" in {
       forAll(arbitrary[UserAnswers]) {
         answers =>
-          val updatedAnswer = answers.set(ExtraInformationPage(index, referenceIndex), "text").success.value
+          val updatedAnswer = answers.set(ExtraInformationPage(itemIndex, referenceIndex), "text").success.value
 
           navigator
-            .nextPage(ExtraInformationPage(index, referenceIndex), NormalMode, updatedAnswer)
-            .mustBe(previousReferenceRoutes.AddAnotherPreviousAdministrativeReferenceController.onPageLoad(answers.lrn, index, NormalMode))
+            .nextPage(ExtraInformationPage(itemIndex, referenceIndex), NormalMode, updatedAnswer)
+            .mustBe(previousReferenceRoutes.ReferenceCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, referenceIndex, NormalMode))
       }
     }
 
@@ -93,12 +93,12 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
         forAll(arbitrary[UserAnswers]) {
           answers =>
             val updatedAnswer = answers
-              .remove(PreviousReferencesQuery(index)).success.value
-              .set(AddAnotherPreviousAdministrativeReferencePage(index), true).success.value
+              .remove(PreviousReferencesQuery(itemIndex)).success.value
+              .set(AddAnotherPreviousAdministrativeReferencePage(itemIndex), true).success.value
 
             navigator
-              .nextPage(AddAnotherPreviousAdministrativeReferencePage(index), NormalMode, updatedAnswer)
-              .mustBe(previousReferenceRoutes.ReferenceTypeController.onPageLoad(answers.lrn, index, index, NormalMode))
+              .nextPage(AddAnotherPreviousAdministrativeReferencePage(itemIndex), NormalMode, updatedAnswer)
+              .mustBe(previousReferenceRoutes.ReferenceTypeController.onPageLoad(answers.lrn, itemIndex, referenceIndex, NormalMode))
         }
       }
 
@@ -106,13 +106,13 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
         forAll(arbitrary[UserAnswers]) {
           answers =>
             val updatedAnswer = answers
-              .remove(PreviousReferencesQuery(index)).success.value
-              .set(AddAnotherPreviousAdministrativeReferencePage(index), false).success.value
+              .remove(PreviousReferencesQuery(itemIndex)).success.value
+              .set(AddAnotherPreviousAdministrativeReferencePage(itemIndex), false).success.value
               .set(AddSecurityDetailsPage, false).success.value
 
             navigator
-              .nextPage(AddAnotherPreviousAdministrativeReferencePage(index), NormalMode, updatedAnswer)
-              .mustBe(routes.ItemsCheckYourAnswersController.onPageLoad(updatedAnswer.lrn, index))
+              .nextPage(AddAnotherPreviousAdministrativeReferencePage(itemIndex), NormalMode, updatedAnswer)
+              .mustBe(routes.ItemsCheckYourAnswersController.onPageLoad(updatedAnswer.lrn, itemIndex))
         }
       }
 
@@ -124,12 +124,12 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
         forAll(arbitrary[UserAnswers]) {
           answers =>
             val updatedAnswer = answers
-              .set(ReferenceTypePage(index, referenceIndex), "T1").success.value
-              .set(ReferenceTypePage(index, Index(1)), "T1").success.value
-              .set(ConfirmRemovePreviousAdministrativeReferencePage(index, referenceIndex), true).success.value
+              .set(ReferenceTypePage(itemIndex, referenceIndex), "T1").success.value
+              .set(ReferenceTypePage(itemIndex, Index(1)), "T1").success.value
+              .set(ConfirmRemovePreviousAdministrativeReferencePage(itemIndex, referenceIndex), true).success.value
             navigator
-              .nextPage(ConfirmRemovePreviousAdministrativeReferencePage(index, referenceIndex), NormalMode, updatedAnswer)
-              .mustBe(previousReferenceRoutes.AddAnotherPreviousAdministrativeReferenceController.onPageLoad(answers.lrn, index, NormalMode))
+              .nextPage(ConfirmRemovePreviousAdministrativeReferencePage(itemIndex, referenceIndex), NormalMode, updatedAnswer)
+              .mustBe(previousReferenceRoutes.AddAnotherPreviousAdministrativeReferenceController.onPageLoad(answers.lrn, itemIndex, NormalMode))
         }
       }
 
@@ -137,12 +137,12 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
         forAll(arbitrary[UserAnswers]) {
           answers =>
             val updatedAnswer = answers
-              .remove(PreviousReferencesQuery(index)).success.value
-              .set(ConfirmRemovePreviousAdministrativeReferencePage(index, referenceIndex), true).success.value
+              .remove(PreviousReferencesQuery(itemIndex)).success.value
+              .set(ConfirmRemovePreviousAdministrativeReferencePage(itemIndex, referenceIndex), true).success.value
 
             navigator
-              .nextPage(ConfirmRemovePreviousAdministrativeReferencePage(index, referenceIndex), NormalMode, updatedAnswer)
-              .mustBe(previousReferenceRoutes.AddAdministrativeReferenceController.onPageLoad(answers.lrn, index, NormalMode))
+              .nextPage(ConfirmRemovePreviousAdministrativeReferencePage(itemIndex, referenceIndex), NormalMode, updatedAnswer)
+              .mustBe(previousReferenceRoutes.AddAdministrativeReferenceController.onPageLoad(answers.lrn, itemIndex, NormalMode))
         }
       }
 
@@ -151,11 +151,11 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
         forAll(arbitrary[UserAnswers]) {
           answers =>
             val updatedAnswers = answers
-              .remove(PreviousReferencesQuery(index)).success.value
-              .set(AddAdministrativeReferencePage(index), true).success.value
+              .remove(PreviousReferencesQuery(itemIndex)).success.value
+              .set(AddAdministrativeReferencePage(itemIndex), true).success.value
             navigator
-              .nextPage(AddAdministrativeReferencePage(index), NormalMode, updatedAnswers)
-              .mustBe(previousReferenceRoutes.ReferenceTypeController.onPageLoad(updatedAnswers.lrn, index, referenceIndex, NormalMode))
+              .nextPage(AddAdministrativeReferencePage(itemIndex), NormalMode, updatedAnswers)
+              .mustBe(previousReferenceRoutes.ReferenceTypeController.onPageLoad(updatedAnswers.lrn, itemIndex, referenceIndex, NormalMode))
         }
       }
 
@@ -165,10 +165,10 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
             val updatedAnswers = answers
               .set(AddSecurityDetailsPage, true).success.value
               .set(AddTransportChargesPaymentMethodPage, false).success.value
-              .set(AddAdministrativeReferencePage(index), false).success.value
+              .set(AddAdministrativeReferencePage(itemIndex), false).success.value
 
             navigator
-              .nextPage(AddAdministrativeReferencePage(index), NormalMode, updatedAnswers)
+              .nextPage(AddAdministrativeReferencePage(itemIndex), NormalMode, updatedAnswers)
               .mustBe(controllers.addItems.securityDetails.routes.TransportChargesController.onPageLoad(updatedAnswers.lrn, itemIndex, NormalMode))
         }
       }
@@ -177,11 +177,11 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
         forAll(arbitrary[UserAnswers]) {
           answers =>
             val updatedAnswers = answers
-              .set(AddAdministrativeReferencePage(index), false).success.value
+              .set(AddAdministrativeReferencePage(itemIndex), false).success.value
               .set(AddSecurityDetailsPage, false).success.value
             navigator
-              .nextPage(AddAdministrativeReferencePage(index), NormalMode, updatedAnswers)
-              .mustBe(routes.ItemsCheckYourAnswersController.onPageLoad(updatedAnswers.lrn, index))
+              .nextPage(AddAdministrativeReferencePage(itemIndex), NormalMode, updatedAnswers)
+              .mustBe(routes.ItemsCheckYourAnswersController.onPageLoad(updatedAnswers.lrn, itemIndex))
         }
       }
 
@@ -193,10 +193,10 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
               .set(AddSecurityDetailsPage, true).success.value
               .set(AddTransportChargesPaymentMethodPage, true).success.value
               .set(AddCommercialReferenceNumberAllItemsPage, false).success.value
-              .set(AddAdministrativeReferencePage(index), false).success.value
+              .set(AddAdministrativeReferencePage(itemIndex), false).success.value
 
             navigator
-              .nextPage(AddAdministrativeReferencePage(index), NormalMode, updatedAnswers)
+              .nextPage(AddAdministrativeReferencePage(itemIndex), NormalMode, updatedAnswers)
               .mustBe(controllers.addItems.securityDetails.routes.CommercialReferenceNumberController.onPageLoad(updatedAnswers.lrn, itemIndex, NormalMode))
         }
       }
@@ -209,10 +209,10 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
               .set(AddSecurityDetailsPage, true).success.value
               .set(AddTransportChargesPaymentMethodPage, true).success.value
               .set(AddCommercialReferenceNumberAllItemsPage, true).success.value
-              .set(AddAdministrativeReferencePage(index), false).success.value
+              .set(AddAdministrativeReferencePage(itemIndex), false).success.value
 
             navigator
-              .nextPage(AddAdministrativeReferencePage(index), NormalMode, updatedAnswers)
+              .nextPage(AddAdministrativeReferencePage(itemIndex), NormalMode, updatedAnswers)
               .mustBe(controllers.addItems.securityDetails.routes.AddDangerousGoodsCodeController.onPageLoad(updatedAnswers.lrn, itemIndex, NormalMode))
         }
       }
@@ -224,10 +224,10 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
             val updatedAnswers = answers
               .set(AddSecurityDetailsPage, true).success.value
               .set(AddTransportChargesPaymentMethodPage, false).success.value
-              .set(AddAnotherPreviousAdministrativeReferencePage(index), false).success.value
+              .set(AddAnotherPreviousAdministrativeReferencePage(itemIndex), false).success.value
 
             navigator
-              .nextPage(AddAnotherPreviousAdministrativeReferencePage(index), NormalMode, updatedAnswers)
+              .nextPage(AddAnotherPreviousAdministrativeReferencePage(itemIndex), NormalMode, updatedAnswers)
               .mustBe(controllers.addItems.securityDetails.routes.TransportChargesController.onPageLoad(updatedAnswers.lrn, itemIndex, NormalMode))
         }
       }
@@ -236,11 +236,11 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
         forAll(arbitrary[UserAnswers]) {
           answers =>
             val updatedAnswers = answers
-              .set(AddAnotherPreviousAdministrativeReferencePage(index), false).success.value
+              .set(AddAnotherPreviousAdministrativeReferencePage(itemIndex), false).success.value
               .set(AddSecurityDetailsPage, false).success.value
             navigator
-              .nextPage(AddAnotherPreviousAdministrativeReferencePage(index), NormalMode, updatedAnswers)
-              .mustBe(routes.ItemsCheckYourAnswersController.onPageLoad(updatedAnswers.lrn, index))
+              .nextPage(AddAnotherPreviousAdministrativeReferencePage(itemIndex), NormalMode, updatedAnswers)
+              .mustBe(routes.ItemsCheckYourAnswersController.onPageLoad(updatedAnswers.lrn, itemIndex))
         }
       }
 
@@ -252,10 +252,10 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
               .set(AddSecurityDetailsPage, true).success.value
               .set(AddTransportChargesPaymentMethodPage, true).success.value
               .set(AddCommercialReferenceNumberAllItemsPage, false).success.value
-              .set(AddAnotherPreviousAdministrativeReferencePage(index), false).success.value
+              .set(AddAnotherPreviousAdministrativeReferencePage(itemIndex), false).success.value
 
             navigator
-              .nextPage(AddAnotherPreviousAdministrativeReferencePage(index), NormalMode, updatedAnswers)
+              .nextPage(AddAnotherPreviousAdministrativeReferencePage(itemIndex), NormalMode, updatedAnswers)
               .mustBe(controllers.addItems.securityDetails.routes.CommercialReferenceNumberController.onPageLoad(updatedAnswers.lrn, itemIndex, NormalMode))
         }
       }
@@ -268,10 +268,10 @@ class AddItemsAdminReferenceNormalModeNavigatorSpec extends SpecBase with ScalaC
               .set(AddSecurityDetailsPage, true).success.value
               .set(AddTransportChargesPaymentMethodPage, true).success.value
               .set(AddCommercialReferenceNumberAllItemsPage, true).success.value
-              .set(AddAnotherPreviousAdministrativeReferencePage(index), false).success.value
+              .set(AddAnotherPreviousAdministrativeReferencePage(itemIndex), false).success.value
 
             navigator
-              .nextPage(AddAnotherPreviousAdministrativeReferencePage(index), NormalMode, updatedAnswers)
+              .nextPage(AddAnotherPreviousAdministrativeReferencePage(itemIndex), NormalMode, updatedAnswers)
               .mustBe(controllers.addItems.securityDetails.routes.AddDangerousGoodsCodeController.onPageLoad(updatedAnswers.lrn, itemIndex, NormalMode))
         }
       }

--- a/test/navigation/AddItemsDocumentCheckModeNavigatorSpec.scala
+++ b/test/navigation/AddItemsDocumentCheckModeNavigatorSpec.scala
@@ -81,12 +81,12 @@ class AddItemsDocumentCheckModeNavigatorSpec extends SpecBase with ScalaCheckPro
 
 
     "AddDocumentExtraInformationPage must go to" - {
-      "AddAnotherDocumentPage if user selects 'No'" in {
+      "CYA if user selects 'No'" in {
         val updatedAnswers = emptyUserAnswers
           .set(AddExtraDocumentInformationPage(index, documentIndex), false).success.value
         navigator
           .nextPage(AddExtraDocumentInformationPage(index, documentIndex), CheckMode, updatedAnswers)
-          .mustBe(controllers.addItems.documents.routes.AddAnotherDocumentController.onPageLoad(updatedAnswers.lrn, index, CheckMode))
+          .mustBe(controllers.addItems.documents.routes.DocumentCheckYourAnswersController.onPageLoad(updatedAnswers.lrn, index, documentIndex, CheckMode))
       }
 
       "DocumentExtraInformationPage if user selects 'Yes'" in {
@@ -98,12 +98,12 @@ class AddItemsDocumentCheckModeNavigatorSpec extends SpecBase with ScalaCheckPro
       }
     }
 
-    "DocumentExtraInformationPage must go to AddAnotherDocumentPage" in {
+    "DocumentExtraInformationPage must go to CYA" in {
       val updatedAnswers = emptyUserAnswers
         .set(DocumentExtraInformationPage(index, documentIndex), "Test").success.value
       navigator
         .nextPage(DocumentExtraInformationPage(index, documentIndex), CheckMode, updatedAnswers)
-        .mustBe(controllers.addItems.documents.routes.AddAnotherDocumentController.onPageLoad(updatedAnswers.lrn, index, CheckMode))
+        .mustBe(controllers.addItems.documents.routes.DocumentCheckYourAnswersController.onPageLoad(updatedAnswers.lrn, index, documentIndex, CheckMode))
     }
 
     "AddAnotherDocumentPage must go to" - {

--- a/test/navigation/AddItemsDocumentNormalModeNavigatorSpec.scala
+++ b/test/navigation/AddItemsDocumentNormalModeNavigatorSpec.scala
@@ -103,21 +103,21 @@ class AddItemsDocumentNormalModeNavigatorSpec extends SpecBase with ScalaCheckPr
             .mustBe(controllers.addItems.documents.routes.DocumentExtraInformationController.onPageLoad(updatedAnswers.lrn, index, documentIndex, NormalMode))
         }
 
-        "AddAnotherDocument page when user selects 'No' " in {
+        "CYA page when user selects 'No' " in {
           val updatedAnswers = emptyUserAnswers
             .set(AddExtraDocumentInformationPage(index, documentIndex), false).success.value
           navigator
             .nextPage(AddExtraDocumentInformationPage(index, documentIndex), NormalMode, updatedAnswers)
-            .mustBe(controllers.addItems.documents.routes.AddAnotherDocumentController.onPageLoad(updatedAnswers.lrn, index, NormalMode))
+            .mustBe(controllers.addItems.documents.routes.DocumentCheckYourAnswersController.onPageLoad(updatedAnswers.lrn, index, documentIndex, NormalMode))
         }
       }
 
-      "DocumentExtraInformationPage must go to AddAnotherDocument" in {
+      "DocumentExtraInformationPage must go to CYA" in {
         val updatedAnswers = emptyUserAnswers
           .set(DocumentExtraInformationPage(index, documentIndex), "test").success.value
         navigator
           .nextPage(DocumentExtraInformationPage(index, documentIndex), NormalMode, updatedAnswers)
-          .mustBe(controllers.addItems.documents.routes.AddAnotherDocumentController.onPageLoad(updatedAnswers.lrn, index, NormalMode))
+          .mustBe(controllers.addItems.documents.routes.DocumentCheckYourAnswersController.onPageLoad(updatedAnswers.lrn, index, documentIndex, NormalMode))
       }
 
       "AddAnotherDocument page must go to" - {

--- a/test/navigation/AddItemsPackageInfoNormalModeNavigatorSpec.scala
+++ b/test/navigation/AddItemsPackageInfoNormalModeNavigatorSpec.scala
@@ -132,7 +132,7 @@ class AddItemsPackageInfoNormalModeNavigatorSpec extends SpecBase with ScalaChec
 
                 navigator
                   .nextPage(AddMarkPage(itemIndex, packageIndex), NormalMode, updatedAnswers)
-                  .mustBe(packageRoutes.PackagesCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, packageIndex, NormalMode))
+                  .mustBe(packageRoutes.PackageCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, packageIndex, NormalMode))
             }
           }
         }
@@ -146,7 +146,7 @@ class AddItemsPackageInfoNormalModeNavigatorSpec extends SpecBase with ScalaChec
 
                 navigator
                   .nextPage(DeclareMarkPage(itemIndex, packageIndex), NormalMode, updatedAnswers)
-                  .mustBe(packageRoutes.PackagesCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, packageIndex, NormalMode))
+                  .mustBe(packageRoutes.PackageCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, packageIndex, NormalMode))
             }
           }
         }

--- a/test/navigation/AddItemsPackageInfoNormalModeNavigatorSpec.scala
+++ b/test/navigation/AddItemsPackageInfoNormalModeNavigatorSpec.scala
@@ -19,6 +19,7 @@ package navigation
 import base.SpecBase
 import commonTestUtils.UserAnswersSpecHelper
 import controllers.addItems.containers.{routes => containerRoutes}
+import controllers.addItems.packagesInformation.{routes => packageRoutes}
 import controllers.addItems.specialMentions.{routes => specialMentionsRoutes}
 import generators.Generators
 import models.reference.PackageType
@@ -49,11 +50,11 @@ class AddItemsPackageInfoNormalModeNavigatorSpec extends SpecBase with ScalaChec
             forAll(arbitrary[UserAnswers], arbitrary[PackageType]) {
               (answers, packageType) =>
                 val updatedAnswers = answers
-                  .set(PackageTypePage(index, index), packageType).success.value
+                  .set(PackageTypePage(itemIndex, packageIndex), packageType).success.value
 
                 navigator
-                  .nextPage(PackageTypePage(index, index), NormalMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.HowManyPackagesController.onPageLoad(answers.lrn, itemIndex, packageIndex, NormalMode))
+                  .nextPage(PackageTypePage(itemIndex, packageIndex), NormalMode, updatedAnswers)
+                  .mustBe(packageRoutes.HowManyPackagesController.onPageLoad(answers.lrn, itemIndex, packageIndex, NormalMode))
             }
           }
 
@@ -62,11 +63,11 @@ class AddItemsPackageInfoNormalModeNavigatorSpec extends SpecBase with ScalaChec
             forAll(arbitrary[UserAnswers], arbitraryBulkPackageType.arbitrary) {
               (answers, packageType) =>
                 val updatedAnswers = answers
-                  .set(PackageTypePage(index, index), packageType).success.value
+                  .set(PackageTypePage(itemIndex, packageIndex), packageType).success.value
 
                 navigator
-                  .nextPage(PackageTypePage(index, index), NormalMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.AddMarkController.onPageLoad(answers.lrn, index, index, NormalMode))
+                  .nextPage(PackageTypePage(itemIndex, packageIndex), NormalMode, updatedAnswers)
+                  .mustBe(packageRoutes.AddMarkController.onPageLoad(answers.lrn, itemIndex, packageIndex, NormalMode))
             }
           }
 
@@ -75,11 +76,11 @@ class AddItemsPackageInfoNormalModeNavigatorSpec extends SpecBase with ScalaChec
             forAll(arbitrary[UserAnswers], arbitraryUnPackedPackageType.arbitrary) {
               (answers, packageType) =>
                 val updatedAnswers = answers
-                  .set(PackageTypePage(index, index), packageType).success.value
+                  .set(PackageTypePage(itemIndex, packageIndex), packageType).success.value
 
                 navigator
-                  .nextPage(PackageTypePage(index, index), NormalMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.TotalPiecesController.onPageLoad(answers.lrn, index, index, NormalMode))
+                  .nextPage(PackageTypePage(itemIndex, packageIndex), NormalMode, updatedAnswers)
+                  .mustBe(packageRoutes.TotalPiecesController.onPageLoad(answers.lrn, itemIndex, packageIndex, NormalMode))
             }
           }
         }
@@ -88,12 +89,12 @@ class AddItemsPackageInfoNormalModeNavigatorSpec extends SpecBase with ScalaChec
             forAll(arbitrary[UserAnswers], arbitrary[PackageType], arbitrary[Int]) {
               (answers, packageType, howManyPackages) =>
                 val updatedAnswers = answers
-                  .set(PackageTypePage(index, index), packageType).success.value
-                  .set(HowManyPackagesPage(index, index), howManyPackages).success.value
+                  .set(PackageTypePage(itemIndex, packageIndex), packageType).success.value
+                  .set(HowManyPackagesPage(itemIndex, packageIndex), howManyPackages).success.value
 
                 navigator
-                  .nextPage(HowManyPackagesPage(index, index), NormalMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.DeclareMarkController.onPageLoad(answers.lrn, index, index, NormalMode))
+                  .nextPage(HowManyPackagesPage(itemIndex, packageIndex), NormalMode, updatedAnswers)
+                  .mustBe(packageRoutes.DeclareMarkController.onPageLoad(answers.lrn, itemIndex, packageIndex, NormalMode))
             }
           }
 
@@ -105,8 +106,8 @@ class AddItemsPackageInfoNormalModeNavigatorSpec extends SpecBase with ScalaChec
                   .set(TotalPackagesPage, totalPieces).success.value
 
                 navigator
-                  .nextPage(TotalPiecesPage(index, index), NormalMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.AddMarkController.onPageLoad(answers.lrn, index, index, NormalMode))
+                  .nextPage(TotalPiecesPage(itemIndex, packageIndex), NormalMode, updatedAnswers)
+                  .mustBe(packageRoutes.AddMarkController.onPageLoad(answers.lrn, itemIndex, packageIndex, NormalMode))
             }
           }
         }
@@ -116,36 +117,36 @@ class AddItemsPackageInfoNormalModeNavigatorSpec extends SpecBase with ScalaChec
             forAll(arbitrary[UserAnswers]) {
               answers =>
                 val updatedAnswers = answers
-                  .set(AddMarkPage(index, index), true).success.value
+                  .set(AddMarkPage(itemIndex, packageIndex), true).success.value
 
                 navigator
-                  .nextPage(AddMarkPage(index, index), NormalMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.DeclareMarkController.onPageLoad(answers.lrn, index, index, NormalMode))
+                  .nextPage(AddMarkPage(itemIndex, packageIndex), NormalMode, updatedAnswers)
+                  .mustBe(packageRoutes.DeclareMarkController.onPageLoad(answers.lrn, itemIndex, packageIndex, NormalMode))
             }
           }
-          "must go to AddAnotherPackage if answers if 'No'" in {
+          "must go to CYA if answers if 'No'" in {
             forAll(arbitrary[UserAnswers]) {
               answers =>
                 val updatedAnswers = answers
-                  .set(AddMarkPage(index, index), false).success.value
+                  .set(AddMarkPage(itemIndex, packageIndex), false).success.value
 
                 navigator
-                  .nextPage(AddMarkPage(index, index), NormalMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.AddAnotherPackageController.onPageLoad(answers.lrn, index, NormalMode))
+                  .nextPage(AddMarkPage(itemIndex, packageIndex), NormalMode, updatedAnswers)
+                  .mustBe(packageRoutes.PackagesCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, packageIndex, NormalMode))
             }
           }
         }
 
         "DeclareMark" - {
-          "must go to AddAnotherPackage" in {
+          "must go to CYA" in {
             forAll(arbitrary[UserAnswers], arbitrary[String]) {
               (answers, declareMark) =>
                 val updatedAnswers = answers
-                  .set(DeclareMarkPage(index, index), declareMark).success.value
+                  .set(DeclareMarkPage(itemIndex, packageIndex), declareMark).success.value
 
                 navigator
-                  .nextPage(DeclareMarkPage(index, index), NormalMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.AddAnotherPackageController.onPageLoad(answers.lrn, index, NormalMode))
+                  .nextPage(DeclareMarkPage(itemIndex, packageIndex), NormalMode, updatedAnswers)
+                  .mustBe(packageRoutes.PackagesCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, packageIndex, NormalMode))
             }
           }
         }
@@ -155,14 +156,14 @@ class AddItemsPackageInfoNormalModeNavigatorSpec extends SpecBase with ScalaChec
             forAll(arbitrary[UserAnswers], arbitrary[PackageType]) {
               (answers, packageType) =>
                 val updatedAnswers = answers
-                  .set(PackageTypePage(index, index), packageType).success.value
+                  .set(PackageTypePage(itemIndex, packageIndex), packageType).success.value
                   .set(AddAnotherPackagePage(index), true).success.value
 
                 val nextPackageIndex = Index(index.position + 1)
 
                 navigator
                   .nextPage(AddAnotherPackagePage(index), NormalMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.PackageTypeController.onPageLoad(answers.lrn, index, nextPackageIndex, NormalMode))
+                  .mustBe(packageRoutes.PackageTypeController.onPageLoad(answers.lrn, index, nextPackageIndex, NormalMode))
             }
           }
 
@@ -217,13 +218,13 @@ class AddItemsPackageInfoNormalModeNavigatorSpec extends SpecBase with ScalaChec
             forAll(arbitrary[UserAnswers], arbitrary[PackageType]) {
               (answers, packageType) =>
                 val updatedAnswers = answers
-                  .set(PackageTypePage(index, index), packageType).success.value
-                  .set(PackageTypePage(index, index), packageType).success.value
+                  .set(PackageTypePage(itemIndex, packageIndex), packageType).success.value
+                  .set(PackageTypePage(itemIndex, packageIndex), packageType).success.value
                   .set(AddAnotherPackagePage(index), true).success.value
                   .set(RemovePackagePage(index), false).success.value
                 navigator
                   .nextPage(RemovePackagePage(index), NormalMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.AddAnotherPackageController.onPageLoad(answers.lrn, index, NormalMode))
+                  .mustBe(packageRoutes.AddAnotherPackageController.onPageLoad(answers.lrn, index, NormalMode))
             }
           }
 
@@ -231,23 +232,23 @@ class AddItemsPackageInfoNormalModeNavigatorSpec extends SpecBase with ScalaChec
             forAll(arbitrary[UserAnswers], arbitrary[PackageType]) {
               (answers, packageType) =>
                 val updatedAnswers = answers
-                  .set(PackageTypePage(index, index), packageType).success.value
-                  .set(PackageTypePage(index, index), packageType).success.value
+                  .set(PackageTypePage(itemIndex, packageIndex), packageType).success.value
+                  .set(PackageTypePage(itemIndex, packageIndex), packageType).success.value
                   .set(AddAnotherPackagePage(index), true).success.value
                   .set(RemovePackagePage(index), true).success.value
                 navigator
                   .nextPage(RemovePackagePage(index), NormalMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.AddAnotherPackageController.onPageLoad(answers.lrn, index, NormalMode))
+                  .mustBe(packageRoutes.AddAnotherPackageController.onPageLoad(answers.lrn, index, NormalMode))
             }
           }
 
           "must go to PackageType page when 'Yes' is selected and all the packages are removed" in {
             val updatedAnswers = emptyUserAnswers
-              .remove(PackagesQuery(index, index)).success.value
+              .remove(PackagesQuery(itemIndex, packageIndex)).success.value
               .set(RemovePackagePage(index), true).success.value
             navigator
               .nextPage(RemovePackagePage(index), NormalMode, updatedAnswers)
-              .mustBe(controllers.addItems.packagesInformation.routes.PackageTypeController.onPageLoad(updatedAnswers.lrn, index, index, NormalMode))
+              .mustBe(packageRoutes.PackageTypeController.onPageLoad(updatedAnswers.lrn, itemIndex, packageIndex, NormalMode))
           }
         }
 

--- a/test/navigation/AddItemsPackagesInfoCheckModeNavigatorSpec.scala
+++ b/test/navigation/AddItemsPackagesInfoCheckModeNavigatorSpec.scala
@@ -19,6 +19,7 @@ package navigation
 import base.SpecBase
 import commonTestUtils.UserAnswersSpecHelper
 import controllers.addItems.containers.{routes => containerRoutes}
+import controllers.addItems.packagesInformation.{routes => packageRoutes}
 import controllers.addItems.routes
 import generators.Generators
 import models.reference.PackageType
@@ -49,11 +50,11 @@ class AddItemsPackagesInfoCheckModeNavigatorSpec extends SpecBase with ScalaChec
             forAll(arbitrary[UserAnswers], arbitrary[PackageType]) {
               (answers, packageType) =>
                 val updatedAnswers = answers
-                  .set(PackageTypePage(index, index), packageType).success.value
+                  .set(PackageTypePage(itemIndex, packageIndex), packageType).success.value
 
                 navigator
-                  .nextPage(PackageTypePage(index, index), CheckMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.HowManyPackagesController.onPageLoad(answers.lrn, index, index, CheckMode))
+                  .nextPage(PackageTypePage(itemIndex, packageIndex), CheckMode, updatedAnswers)
+                  .mustBe(packageRoutes.HowManyPackagesController.onPageLoad(answers.lrn, itemIndex, packageIndex, CheckMode))
             }
           }
 
@@ -62,11 +63,11 @@ class AddItemsPackagesInfoCheckModeNavigatorSpec extends SpecBase with ScalaChec
             forAll(arbitrary[UserAnswers], arbitraryBulkPackageType.arbitrary) {
               (answers, packageType) =>
                 val updatedAnswers = answers
-                  .set(PackageTypePage(index, index), packageType).success.value
+                  .set(PackageTypePage(itemIndex, packageIndex), packageType).success.value
 
                 navigator
-                  .nextPage(PackageTypePage(index, index), CheckMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.AddMarkController.onPageLoad(answers.lrn, index, index, CheckMode))
+                  .nextPage(PackageTypePage(itemIndex, packageIndex), CheckMode, updatedAnswers)
+                  .mustBe(packageRoutes.AddMarkController.onPageLoad(answers.lrn, itemIndex, packageIndex, CheckMode))
             }
           }
 
@@ -75,26 +76,26 @@ class AddItemsPackagesInfoCheckModeNavigatorSpec extends SpecBase with ScalaChec
             forAll(arbitrary[UserAnswers], arbitraryUnPackedPackageType.arbitrary) {
               (answers, packageType) =>
                 val updatedAnswers = answers
-                  .set(PackageTypePage(index, index), packageType).success.value
+                  .set(PackageTypePage(itemIndex, packageIndex), packageType).success.value
 
                 navigator
-                  .nextPage(PackageTypePage(index, index), CheckMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.TotalPiecesController.onPageLoad(answers.lrn, index, index, CheckMode))
+                  .nextPage(PackageTypePage(itemIndex, packageIndex), CheckMode, updatedAnswers)
+                  .mustBe(packageRoutes.TotalPiecesController.onPageLoad(answers.lrn, itemIndex, packageIndex, CheckMode))
             }
           }
         }
         "HowManyPackages must go to AddMark page" in {
-            forAll(arbitrary[UserAnswers], arbitraryBulkPackageType.arbitrary, arbitrary[Int]) {
-              (answers, packageType, howManyPackages) =>
-                val updatedAnswers = answers
-                  .set(PackageTypePage(index, index), packageType).success.value
-                  .set(HowManyPackagesPage(index, index), howManyPackages).success.value
+          forAll(arbitrary[UserAnswers], arbitraryBulkPackageType.arbitrary, arbitrary[Int]) {
+            (answers, packageType, howManyPackages) =>
+              val updatedAnswers = answers
+                .set(PackageTypePage(itemIndex, packageIndex), packageType).success.value
+                .set(HowManyPackagesPage(itemIndex, packageIndex), howManyPackages).success.value
 
-                navigator
-                  .nextPage(HowManyPackagesPage(index, index), CheckMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.DeclareMarkController.onPageLoad(answers.lrn, index, index, CheckMode))
-            }
+              navigator
+                .nextPage(HowManyPackagesPage(itemIndex, packageIndex), CheckMode, updatedAnswers)
+                .mustBe(packageRoutes.DeclareMarkController.onPageLoad(answers.lrn, itemIndex, packageIndex, CheckMode))
           }
+        }
 
         "TotalPieces" - {
           "must go to AddMark" in {
@@ -104,8 +105,8 @@ class AddItemsPackagesInfoCheckModeNavigatorSpec extends SpecBase with ScalaChec
                   .set(TotalPackagesPage, totalPieces).success.value
 
                 navigator
-                  .nextPage(TotalPiecesPage(index, index), CheckMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.AddMarkController.onPageLoad(answers.lrn, index, index, CheckMode))
+                  .nextPage(TotalPiecesPage(itemIndex, packageIndex), CheckMode, updatedAnswers)
+                  .mustBe(packageRoutes.AddMarkController.onPageLoad(answers.lrn, itemIndex, packageIndex, CheckMode))
             }
           }
         }
@@ -115,22 +116,22 @@ class AddItemsPackagesInfoCheckModeNavigatorSpec extends SpecBase with ScalaChec
             forAll(arbitrary[UserAnswers]) {
               answers =>
                 val updatedAnswers = answers
-                  .set(AddMarkPage(index, index), true).success.value
+                  .set(AddMarkPage(itemIndex, packageIndex), true).success.value
 
                 navigator
-                  .nextPage(AddMarkPage(index, index), CheckMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.DeclareMarkController.onPageLoad(answers.lrn, index, index, CheckMode))
+                  .nextPage(AddMarkPage(itemIndex, packageIndex), CheckMode, updatedAnswers)
+                  .mustBe(packageRoutes.DeclareMarkController.onPageLoad(answers.lrn, itemIndex, packageIndex, CheckMode))
             }
           }
           "must go to CheckYourAnswers if answers if 'No'" in {
             forAll(arbitrary[UserAnswers]) {
               answers =>
                 val updatedAnswers = answers
-                  .set(AddMarkPage(index, index), false).success.value
+                  .set(AddMarkPage(itemIndex, packageIndex), false).success.value
 
                 navigator
-                  .nextPage(AddMarkPage(index, index), CheckMode, updatedAnswers)
-                  .mustBe(routes.ItemsCheckYourAnswersController.onPageLoad(answers.lrn, index))
+                  .nextPage(AddMarkPage(itemIndex, packageIndex), CheckMode, updatedAnswers)
+                  .mustBe(packageRoutes.PackagesCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, packageIndex, CheckMode))
             }
           }
         }
@@ -140,11 +141,11 @@ class AddItemsPackagesInfoCheckModeNavigatorSpec extends SpecBase with ScalaChec
             forAll(arbitrary[UserAnswers], arbitrary[String]) {
               (answers, declareMark) =>
                 val updatedAnswers = answers
-                  .set(DeclareMarkPage(index, index), declareMark).success.value
+                  .set(DeclareMarkPage(itemIndex, packageIndex), declareMark).success.value
 
                 navigator
-                  .nextPage(DeclareMarkPage(index, index), CheckMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.AddAnotherPackageController.onPageLoad(answers.lrn, index, CheckMode))
+                  .nextPage(DeclareMarkPage(itemIndex, packageIndex), CheckMode, updatedAnswers)
+                  .mustBe(packageRoutes.PackagesCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, packageIndex, CheckMode))
             }
           }
         }
@@ -154,14 +155,14 @@ class AddItemsPackagesInfoCheckModeNavigatorSpec extends SpecBase with ScalaChec
             forAll(arbitrary[UserAnswers], arbitrary[PackageType]) {
               (answers, packageType) =>
                 val updatedAnswers = answers
-                  .set(PackageTypePage(index, index), packageType).success.value
-                  .set(AddAnotherPackagePage(index), true).success.value
+                  .set(PackageTypePage(itemIndex, packageIndex), packageType).success.value
+                  .set(AddAnotherPackagePage(itemIndex), true).success.value
 
-                val nextPackageIndex = Index(index.position + 1)
+                val nextPackageIndex = Index(packageIndex.position + 1)
 
                 navigator
-                  .nextPage(AddAnotherPackagePage(index), CheckMode, updatedAnswers)
-                  .mustBe(controllers.addItems.packagesInformation.routes.PackageTypeController.onPageLoad(answers.lrn, index, nextPackageIndex, CheckMode))
+                  .nextPage(AddAnotherPackagePage(itemIndex), CheckMode, updatedAnswers)
+                  .mustBe(packageRoutes.PackageTypeController.onPageLoad(answers.lrn, itemIndex, nextPackageIndex, CheckMode))
             }
           }
 

--- a/test/navigation/AddItemsPackagesInfoCheckModeNavigatorSpec.scala
+++ b/test/navigation/AddItemsPackagesInfoCheckModeNavigatorSpec.scala
@@ -131,7 +131,7 @@ class AddItemsPackagesInfoCheckModeNavigatorSpec extends SpecBase with ScalaChec
 
                 navigator
                   .nextPage(AddMarkPage(itemIndex, packageIndex), CheckMode, updatedAnswers)
-                  .mustBe(packageRoutes.PackagesCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, packageIndex, CheckMode))
+                  .mustBe(packageRoutes.PackageCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, packageIndex, CheckMode))
             }
           }
         }
@@ -145,7 +145,7 @@ class AddItemsPackagesInfoCheckModeNavigatorSpec extends SpecBase with ScalaChec
 
                 navigator
                   .nextPage(DeclareMarkPage(itemIndex, packageIndex), CheckMode, updatedAnswers)
-                  .mustBe(packageRoutes.PackagesCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, packageIndex, CheckMode))
+                  .mustBe(packageRoutes.PackageCheckYourAnswersController.onPageLoad(answers.lrn, itemIndex, packageIndex, CheckMode))
             }
           }
         }

--- a/test/navigation/AddItemsSpecialMentionsCheckModeNavigatorSpec.scala
+++ b/test/navigation/AddItemsSpecialMentionsCheckModeNavigatorSpec.scala
@@ -33,80 +33,74 @@ class AddItemsSpecialMentionsCheckModeNavigatorSpec extends SpecBase with ScalaC
 
     "in check mode" - {
 
-      "must go from SpecialMentionAdditionalInfoPage to AddAnotherSpecialMentionController" in {
-        navigator
-          .nextPage(SpecialMentionAdditionalInfoPage(index, itemIndex), CheckMode, emptyUserAnswers)
-          .mustBe(routes.AddAnotherSpecialMentionController.onPageLoad(emptyUserAnswers.lrn, index, CheckMode))
-      }
-
       "must go from AddSpecialMentionPage to SpecialMentionTypeController when" - {
 
         "AddSpecialMentionPage is true and no special mentions exist" in {
-          val userAnswers = emptyUserAnswers.set(AddSpecialMentionPage(index), true).success.value
+          val userAnswers = emptyUserAnswers.set(AddSpecialMentionPage(itemIndex), true).success.value
 
           navigator
-            .nextPage(AddSpecialMentionPage(index), CheckMode, userAnswers)
-            .mustBe(routes.SpecialMentionTypeController.onPageLoad(userAnswers.lrn, index, index, CheckMode))
+            .nextPage(AddSpecialMentionPage(itemIndex), CheckMode, userAnswers)
+            .mustBe(routes.SpecialMentionTypeController.onPageLoad(userAnswers.lrn, itemIndex, referenceIndex, CheckMode))
         }
 
         "AddSpecialMentionPage is true and 1 special mention exists" in {
 
           val userAnswers = emptyUserAnswers
-            .set(AddSpecialMentionPage(index), true)
+            .set(AddSpecialMentionPage(itemIndex), true)
             .success
             .value
-            .set(SpecialMentionTypePage(index, index), "value")
+            .set(SpecialMentionTypePage(itemIndex, referenceIndex), "value")
             .success
             .value
 
           navigator
-            .nextPage(AddSpecialMentionPage(index), CheckMode, userAnswers)
-            .mustBe(routes.AddAnotherSpecialMentionController.onPageLoad(userAnswers.lrn, index, CheckMode))
+            .nextPage(AddSpecialMentionPage(itemIndex), CheckMode, userAnswers)
+            .mustBe(routes.AddAnotherSpecialMentionController.onPageLoad(userAnswers.lrn, itemIndex, CheckMode))
         }
 
         "AddSpecialMentionPage is false" in {
 
           val userAnswers = emptyUserAnswers
-            .set(AddSpecialMentionPage(index), false)
+            .set(AddSpecialMentionPage(itemIndex), false)
             .success
             .value
 
           navigator
-            .nextPage(AddSpecialMentionPage(index), CheckMode, userAnswers)
-            .mustBe(controllers.addItems.routes.ItemsCheckYourAnswersController.onPageLoad(userAnswers.lrn, index))
+            .nextPage(AddSpecialMentionPage(itemIndex), CheckMode, userAnswers)
+            .mustBe(controllers.addItems.routes.ItemsCheckYourAnswersController.onPageLoad(userAnswers.lrn, itemIndex))
         }
       }
 
       "must go from SpecialMentionType to SpecialMentionAdditionalInfo" in {
         navigator
-          .nextPage(SpecialMentionTypePage(index, index), CheckMode, emptyUserAnswers)
-          .mustBe(routes.SpecialMentionAdditionalInfoController.onPageLoad(emptyUserAnswers.lrn, index, index, CheckMode))
+          .nextPage(SpecialMentionTypePage(itemIndex, referenceIndex), CheckMode, emptyUserAnswers)
+          .mustBe(routes.SpecialMentionAdditionalInfoController.onPageLoad(emptyUserAnswers.lrn, itemIndex, referenceIndex, CheckMode))
       }
 
       "must go from SpecialMentionAdditionalInfo to AddAnotherSpecialMention" in {
         navigator
-          .nextPage(SpecialMentionAdditionalInfoPage(index, index), CheckMode, emptyUserAnswers)
-          .mustBe(routes.AddAnotherSpecialMentionController.onPageLoad(emptyUserAnswers.lrn, index, CheckMode))
+          .nextPage(SpecialMentionAdditionalInfoPage(itemIndex, referenceIndex), CheckMode, emptyUserAnswers)
+          .mustBe(routes.SpecialMentionCheckYourAnswersController.onPageLoad(emptyUserAnswers.lrn, itemIndex, referenceIndex, CheckMode))
       }
 
       "must go from AddAnotherSpecialMention" - {
 
         "to SpecialMentionType when set to true" in {
 
-          val userAnswers = emptyUserAnswers.set(AddAnotherSpecialMentionPage(index), true).success.value
+          val userAnswers = emptyUserAnswers.set(AddAnotherSpecialMentionPage(itemIndex), true).success.value
 
           navigator
-            .nextPage(AddAnotherSpecialMentionPage(index), CheckMode, userAnswers)
-            .mustBe(routes.SpecialMentionTypeController.onPageLoad(userAnswers.lrn, index, index, CheckMode))
+            .nextPage(AddAnotherSpecialMentionPage(itemIndex), CheckMode, userAnswers)
+            .mustBe(routes.SpecialMentionTypeController.onPageLoad(userAnswers.lrn, itemIndex, referenceIndex, CheckMode))
         }
 
         "to ItemsCheckYourAnswers when set to false" in {
 
-          val userAnswers = emptyUserAnswers.set(AddAnotherSpecialMentionPage(index), false).success.value
+          val userAnswers = emptyUserAnswers.set(AddAnotherSpecialMentionPage(itemIndex), false).success.value
 
           navigator
-            .nextPage(AddAnotherSpecialMentionPage(index), CheckMode, userAnswers)
-            .mustBe(controllers.addItems.routes.ItemsCheckYourAnswersController.onPageLoad(userAnswers.lrn, index))
+            .nextPage(AddAnotherSpecialMentionPage(itemIndex), CheckMode, userAnswers)
+            .mustBe(controllers.addItems.routes.ItemsCheckYourAnswersController.onPageLoad(userAnswers.lrn, itemIndex))
         }
       }
 
@@ -115,19 +109,19 @@ class AddItemsSpecialMentionsCheckModeNavigatorSpec extends SpecBase with ScalaC
         "to AddAnotherSpecialMentionController when at least one special mention exists" in {
 
           val userAnswers = emptyUserAnswers
-            .set(SpecialMentionTypePage(index, index), "value")
+            .set(SpecialMentionTypePage(itemIndex, referenceIndex), "value")
             .success
             .value
 
           navigator
-            .nextPage(RemoveSpecialMentionPage(index, index), CheckMode, userAnswers)
-            .mustBe(routes.AddAnotherSpecialMentionController.onPageLoad(userAnswers.lrn, index, CheckMode))
+            .nextPage(RemoveSpecialMentionPage(itemIndex, referenceIndex), CheckMode, userAnswers)
+            .mustBe(routes.AddAnotherSpecialMentionController.onPageLoad(userAnswers.lrn, itemIndex, CheckMode))
         }
 
         "to AddSpecialMentionPage when no special mentions exist" in {
           navigator
-            .nextPage(RemoveSpecialMentionPage(index, index), CheckMode, emptyUserAnswers)
-            .mustBe(routes.AddSpecialMentionController.onPageLoad(emptyUserAnswers.lrn, index, CheckMode))
+            .nextPage(RemoveSpecialMentionPage(itemIndex, referenceIndex), CheckMode, emptyUserAnswers)
+            .mustBe(routes.AddSpecialMentionController.onPageLoad(emptyUserAnswers.lrn, itemIndex, CheckMode))
         }
       }
     }

--- a/test/navigation/AddItemsSpecialMentionsNormalModeNavigatorSpec.scala
+++ b/test/navigation/AddItemsSpecialMentionsNormalModeNavigatorSpec.scala
@@ -43,11 +43,11 @@ class AddItemsSpecialMentionsNormalModeNavigatorSpec extends SpecBase with Scala
 
         "SpecialMentionType when true" in {
 
-          val userAnswers = emptyUserAnswers.set(AddSpecialMentionPage(index), true).success.value
+          val userAnswers = emptyUserAnswers.set(AddSpecialMentionPage(itemIndex), true).success.value
 
           navigator
-            .nextPage(AddSpecialMentionPage(index), NormalMode, userAnswers)
-            .mustBe(routes.SpecialMentionTypeController.onPageLoad(userAnswers.lrn, index, index, NormalMode))
+            .nextPage(AddSpecialMentionPage(itemIndex), NormalMode, userAnswers)
+            .mustBe(routes.SpecialMentionTypeController.onPageLoad(userAnswers.lrn, itemIndex, referenceIndex, NormalMode))
         }
 
         "to TIRCarnetReference page when false and " +
@@ -58,8 +58,8 @@ class AddItemsSpecialMentionsNormalModeNavigatorSpec extends SpecBase with Scala
               .unsafeSetVal(DeclarationTypePage)(Option4)
 
             navigator
-              .nextPage(AddSpecialMentionPage(index), NormalMode, userAnswers)
-              .mustBe(controllers.addItems.documents.routes.TIRCarnetReferenceController.onPageLoad(userAnswers.lrn, index, itemIndex, NormalMode))
+              .nextPage(AddSpecialMentionPage(itemIndex), NormalMode, userAnswers)
+              .mustBe(controllers.addItems.documents.routes.TIRCarnetReferenceController.onPageLoad(userAnswers.lrn, itemIndex, itemIndex, NormalMode))
           }
 
         "to standard add document journey when false and " +
@@ -82,15 +82,15 @@ class AddItemsSpecialMentionsNormalModeNavigatorSpec extends SpecBase with Scala
 
             val userAnswers = emptyUserAnswers
               .unsafeSetVal(AddSecurityDetailsPage)(true)
-              .unsafeSetVal(DocumentTypePage(index, referenceIndex))("documentType")
-              .unsafeSetVal(DocumentReferencePage(index, referenceIndex))("documentReference")
-              .unsafeSetVal(AddExtraDocumentInformationPage(index, referenceIndex))(true)
-              .unsafeSetVal(DocumentExtraInformationPage(index, referenceIndex))("documentExtraInformation")
+              .unsafeSetVal(DocumentTypePage(itemIndex, referenceIndex))("documentType")
+              .unsafeSetVal(DocumentReferencePage(itemIndex, referenceIndex))("documentReference")
+              .unsafeSetVal(AddExtraDocumentInformationPage(itemIndex, referenceIndex))(true)
+              .unsafeSetVal(DocumentExtraInformationPage(itemIndex, referenceIndex))("documentExtraInformation")
               .unsafeSetVal(DeclarationTypePage)(Option4)
 
             navigator
-              .nextPage(AddSpecialMentionPage(index), NormalMode, userAnswers)
-              .mustBe(controllers.addItems.documents.routes.AddDocumentsController.onPageLoad(userAnswers.lrn, index, NormalMode))
+              .nextPage(AddSpecialMentionPage(itemIndex), NormalMode, userAnswers)
+              .mustBe(controllers.addItems.documents.routes.AddDocumentsController.onPageLoad(userAnswers.lrn, itemIndex, NormalMode))
           }
 
         "to AddDocuments when set to false and safety " +
@@ -101,8 +101,8 @@ class AddItemsSpecialMentionsNormalModeNavigatorSpec extends SpecBase with Scala
               .unsafeSetVal(DeclarationTypePage)(Option1)
 
             navigator
-              .nextPage(AddSpecialMentionPage(index), NormalMode, userAnswers)
-              .mustBe(controllers.addItems.documents.routes.AddDocumentsController.onPageLoad(userAnswers.lrn, index, NormalMode))
+              .nextPage(AddSpecialMentionPage(itemIndex), NormalMode, userAnswers)
+              .mustBe(controllers.addItems.documents.routes.AddDocumentsController.onPageLoad(userAnswers.lrn, itemIndex, NormalMode))
           }
 
         "to DocumentType when set to false " +
@@ -118,8 +118,8 @@ class AddItemsSpecialMentionsNormalModeNavigatorSpec extends SpecBase with Scala
               .unsafeSetVal(DeclarationTypePage)(Option1)
 
             navigator
-              .nextPage(AddSpecialMentionPage(index), NormalMode, userAnswers)
-              .mustBe(controllers.addItems.documents.routes.DocumentTypeController.onPageLoad(userAnswers.lrn, index, itemIndex, NormalMode))
+              .nextPage(AddSpecialMentionPage(itemIndex), NormalMode, userAnswers)
+              .mustBe(controllers.addItems.documents.routes.DocumentTypeController.onPageLoad(userAnswers.lrn, itemIndex, itemIndex, NormalMode))
           }
 
         "to AddDocumentType when set to false and AddSecurityDetailsPage is 'Yes' " +
@@ -153,8 +153,8 @@ class AddItemsSpecialMentionsNormalModeNavigatorSpec extends SpecBase with Scala
               .unsafeSetVal(DeclarationTypePage)(Option1)
 
             navigator
-              .nextPage(AddSpecialMentionPage(index), NormalMode, userAnswers)
-              .mustBe(controllers.addItems.documents.routes.DocumentTypeController.onPageLoad(userAnswers.lrn, index, itemIndex, NormalMode))
+              .nextPage(AddSpecialMentionPage(itemIndex), NormalMode, userAnswers)
+              .mustBe(controllers.addItems.documents.routes.DocumentTypeController.onPageLoad(userAnswers.lrn, itemIndex, itemIndex, NormalMode))
           }
 
         "to DocumentType when set to false and AddSecurityDetailsPage is 'Yes' and " +
@@ -169,22 +169,22 @@ class AddItemsSpecialMentionsNormalModeNavigatorSpec extends SpecBase with Scala
               .unsafeSetVal(DeclarationTypePage)(Option1)
 
             navigator
-              .nextPage(AddSpecialMentionPage(index), NormalMode, userAnswers)
-              .mustBe(controllers.addItems.documents.routes.AddDocumentsController.onPageLoad(userAnswers.lrn, index, NormalMode))
+              .nextPage(AddSpecialMentionPage(itemIndex), NormalMode, userAnswers)
+              .mustBe(controllers.addItems.documents.routes.AddDocumentsController.onPageLoad(userAnswers.lrn, itemIndex, NormalMode))
           }
 
       }
 
       "must go from SpecialMentionType to SpecialMentionAdditionalInfo" in {
         navigator
-          .nextPage(SpecialMentionTypePage(index, index), NormalMode, emptyUserAnswers)
-          .mustBe(routes.SpecialMentionAdditionalInfoController.onPageLoad(emptyUserAnswers.lrn, index, index, NormalMode))
+          .nextPage(SpecialMentionTypePage(itemIndex, referenceIndex), NormalMode, emptyUserAnswers)
+          .mustBe(routes.SpecialMentionAdditionalInfoController.onPageLoad(emptyUserAnswers.lrn, itemIndex, referenceIndex, NormalMode))
       }
 
-      "must go from SpecialMentionAdditionalInfo to AddAnotherSpecialMention" in {
+      "must go from SpecialMentionAdditionalInfo to CYA" in {
         navigator
-          .nextPage(SpecialMentionAdditionalInfoPage(index, index), NormalMode, emptyUserAnswers)
-          .mustBe(routes.AddAnotherSpecialMentionController.onPageLoad(emptyUserAnswers.lrn, index, NormalMode))
+          .nextPage(SpecialMentionAdditionalInfoPage(itemIndex, referenceIndex), NormalMode, emptyUserAnswers)
+          .mustBe(routes.SpecialMentionCheckYourAnswersController.onPageLoad(emptyUserAnswers.lrn, itemIndex, referenceIndex, NormalMode))
       }
 
       "must go from RemoveSpecialMentionController" - {
@@ -192,26 +192,20 @@ class AddItemsSpecialMentionsNormalModeNavigatorSpec extends SpecBase with Scala
         "to AddAnotherSpecialMentionController when at least one special mention exists" in {
 
           val userAnswers = emptyUserAnswers
-            .set(SpecialMentionTypePage(index, index), "value")
+            .set(SpecialMentionTypePage(itemIndex, referenceIndex), "value")
             .success
             .value
 
           navigator
-            .nextPage(RemoveSpecialMentionPage(index, index), NormalMode, userAnswers)
-            .mustBe(routes.AddAnotherSpecialMentionController.onPageLoad(userAnswers.lrn, index, NormalMode))
+            .nextPage(RemoveSpecialMentionPage(itemIndex, referenceIndex), NormalMode, userAnswers)
+            .mustBe(routes.AddAnotherSpecialMentionController.onPageLoad(userAnswers.lrn, itemIndex, NormalMode))
         }
 
         "to AddSpecialMentionPage when no special mentions exist" in {
           navigator
-            .nextPage(RemoveSpecialMentionPage(index, index), NormalMode, emptyUserAnswers)
-            .mustBe(routes.AddSpecialMentionController.onPageLoad(emptyUserAnswers.lrn, index, NormalMode))
+            .nextPage(RemoveSpecialMentionPage(itemIndex, referenceIndex), NormalMode, emptyUserAnswers)
+            .mustBe(routes.AddSpecialMentionController.onPageLoad(emptyUserAnswers.lrn, itemIndex, NormalMode))
         }
-      }
-
-      "must go from SpecialMentionAdditionalInfoPage to AddAnotherSpecialMention" in {
-        navigator
-          .nextPage(SpecialMentionAdditionalInfoPage(index, index), NormalMode, emptyUserAnswers)
-          .mustBe(routes.AddAnotherSpecialMentionController.onPageLoad(emptyUserAnswers.lrn, index, NormalMode))
       }
 
       "must go from AddAnotherSpecialMention" - {
@@ -219,23 +213,23 @@ class AddItemsSpecialMentionsNormalModeNavigatorSpec extends SpecBase with Scala
         "to SpecialMentionType when set to true" in {
 
           val userAnswers = emptyUserAnswers
-            .unsafeSetVal(AddAnotherSpecialMentionPage(index))(true)
+            .unsafeSetVal(AddAnotherSpecialMentionPage(itemIndex))(true)
 
           navigator
-            .nextPage(AddAnotherSpecialMentionPage(index), NormalMode, userAnswers)
-            .mustBe(routes.SpecialMentionTypeController.onPageLoad(userAnswers.lrn, index, index, NormalMode))
+            .nextPage(AddAnotherSpecialMentionPage(itemIndex), NormalMode, userAnswers)
+            .mustBe(routes.SpecialMentionTypeController.onPageLoad(userAnswers.lrn, itemIndex, referenceIndex, NormalMode))
         }
 
         "to AddDocuments when set to false and safeTye and security is selected as 'No'" in {
 
           val userAnswers = emptyUserAnswers
             .unsafeSetVal(AddSecurityDetailsPage)(false)
-            .unsafeSetVal(AddAnotherSpecialMentionPage(index))(false)
+            .unsafeSetVal(AddAnotherSpecialMentionPage(itemIndex))(false)
             .unsafeSetVal(DeclarationTypePage)(Option1)
 
           navigator
-            .nextPage(AddAnotherSpecialMentionPage(index), NormalMode, userAnswers)
-            .mustBe(controllers.addItems.documents.routes.AddDocumentsController.onPageLoad(userAnswers.lrn, index, NormalMode))
+            .nextPage(AddAnotherSpecialMentionPage(itemIndex), NormalMode, userAnswers)
+            .mustBe(controllers.addItems.documents.routes.AddDocumentsController.onPageLoad(userAnswers.lrn, itemIndex, NormalMode))
         }
 
         "to DocumentType when set to false and AddSecurityDetailsPage is 'Yes' and  AddCircumstanceIndicatorPage is 'No' and it is the first Item and AddCommercialReferenceNumberPage is false" in {
@@ -243,13 +237,13 @@ class AddItemsSpecialMentionsNormalModeNavigatorSpec extends SpecBase with Scala
           val userAnswers = emptyUserAnswers
             .unsafeSetVal(AddCircumstanceIndicatorPage)(false)
             .unsafeSetVal(AddSecurityDetailsPage)(true)
-            .unsafeSetVal(AddAnotherSpecialMentionPage(index))(false)
+            .unsafeSetVal(AddAnotherSpecialMentionPage(itemIndex))(false)
             .unsafeSetVal(AddCommercialReferenceNumberPage)(false)
             .unsafeSetVal(DeclarationTypePage)(Option1)
 
           navigator
-            .nextPage(AddAnotherSpecialMentionPage(index), NormalMode, userAnswers)
-            .mustBe(controllers.addItems.documents.routes.DocumentTypeController.onPageLoad(userAnswers.lrn, index, itemIndex, NormalMode))
+            .nextPage(AddAnotherSpecialMentionPage(itemIndex), NormalMode, userAnswers)
+            .mustBe(controllers.addItems.documents.routes.DocumentTypeController.onPageLoad(userAnswers.lrn, itemIndex, itemIndex, NormalMode))
         }
 
         "to AddDocumentType when set to false and AddSecurityDetailsPage is 'Yes' and  AddCircumstanceIndicatorPage is 'No' and it is the not the first Item and AddCommercialReferenceNumberPage is false" in {
@@ -258,7 +252,7 @@ class AddItemsSpecialMentionsNormalModeNavigatorSpec extends SpecBase with Scala
           val userAnswers = emptyUserAnswers
             .unsafeSetVal(AddCircumstanceIndicatorPage)(false)
             .unsafeSetVal(AddSecurityDetailsPage)(true)
-            .unsafeSetVal(AddAnotherSpecialMentionPage(index))(false)
+            .unsafeSetVal(AddAnotherSpecialMentionPage(itemIndex))(false)
             .unsafeSetVal(AddAnotherSpecialMentionPage(nextIndex))(false)
             .unsafeSetVal(AddCommercialReferenceNumberPage)(false)
             .unsafeSetVal(DeclarationTypePage)(Option1)
@@ -276,13 +270,13 @@ class AddItemsSpecialMentionsNormalModeNavigatorSpec extends SpecBase with Scala
             .unsafeSetVal(AddCircumstanceIndicatorPage)(true)
             .unsafeSetVal(CircumstanceIndicatorPage)(circumstanceIndicator)
             .unsafeSetVal(AddSecurityDetailsPage)(true)
-            .unsafeSetVal(AddAnotherSpecialMentionPage(index))(false)
+            .unsafeSetVal(AddAnotherSpecialMentionPage(itemIndex))(false)
             .unsafeSetVal(AddCommercialReferenceNumberPage)(false)
             .unsafeSetVal(DeclarationTypePage)(Option1)
 
           navigator
-            .nextPage(AddAnotherSpecialMentionPage(index), NormalMode, userAnswers)
-            .mustBe(controllers.addItems.documents.routes.DocumentTypeController.onPageLoad(userAnswers.lrn, index, itemIndex, NormalMode))
+            .nextPage(AddAnotherSpecialMentionPage(itemIndex), NormalMode, userAnswers)
+            .mustBe(controllers.addItems.documents.routes.DocumentTypeController.onPageLoad(userAnswers.lrn, itemIndex, itemIndex, NormalMode))
         }
 
         "to DocumentType when set to false and AddSecurityDetailsPage is 'Yes' and  AddCircumstanceIndicatorPage is 'Yes' and CircumstanceIndicator other then E, D, C and B" in {
@@ -291,13 +285,13 @@ class AddItemsSpecialMentionsNormalModeNavigatorSpec extends SpecBase with Scala
             .unsafeSetVal(AddCircumstanceIndicatorPage)(true)
             .unsafeSetVal(CircumstanceIndicatorPage)("something")
             .unsafeSetVal(AddSecurityDetailsPage)(true)
-            .unsafeSetVal(AddAnotherSpecialMentionPage(index))(false)
+            .unsafeSetVal(AddAnotherSpecialMentionPage(itemIndex))(false)
             .unsafeSetVal(AddCommercialReferenceNumberPage)(false)
             .unsafeSetVal(DeclarationTypePage)(Option1)
 
           navigator
-            .nextPage(AddAnotherSpecialMentionPage(index), NormalMode, userAnswers)
-            .mustBe(controllers.addItems.documents.routes.AddDocumentsController.onPageLoad(userAnswers.lrn, index, NormalMode))
+            .nextPage(AddAnotherSpecialMentionPage(itemIndex), NormalMode, userAnswers)
+            .mustBe(controllers.addItems.documents.routes.AddDocumentsController.onPageLoad(userAnswers.lrn, itemIndex, NormalMode))
         }
       }
     }

--- a/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
+++ b/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
@@ -1407,7 +1407,7 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
               actions = List(
                 Action(
                   content = msg"site.edit",
-                  href = PackagesCheckYourAnswersController.onPageLoad(lrn, itemIndex, packageIndex, mode).url,
+                  href = PackageCheckYourAnswersController.onPageLoad(lrn, itemIndex, packageIndex, mode).url,
                   visuallyHiddenText = Some(label),
                   attributes = Map("id" -> s"change-package-${packageIndex.display}")
                 )
@@ -2178,7 +2178,7 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                   content = msg"site.edit",
                   href = ReferenceTypeController.onPageLoad(lrn, index, referenceIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"change-reference-type-${referenceIndex.display}")
+                  attributes = Map("id" -> "change-reference-type")
                 )
               )
             )
@@ -2221,7 +2221,7 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                   content = msg"site.edit",
                   href = PreviousReferenceController.onPageLoad(lrn, index, referenceIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"change-previous-reference-${referenceIndex.display}")
+                  attributes = Map("id" -> "change-previous-reference")
                 )
               )
             )
@@ -2256,13 +2256,13 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
           result mustBe Some(
             Row(
               key = Key(label, classes = Seq("govuk-!-width-one-half")),
-              value = Value(msg"site.yes"),
+              value = Value(msg"site.ye"),
               actions = List(
                 Action(
                   content = msg"site.edit",
                   href = AddExtraInformationController.onPageLoad(lrn, index, referenceIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"change-add-extra-reference-information-${referenceIndex.display}")
+                  attributes = Map("id" -> "change-add-extra-reference-information")
                 )
               )
             )
@@ -2305,7 +2305,7 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                   content = msg"site.edit",
                   href = ExtraInformationController.onPageLoad(lrn, index, referenceIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"change-extra-reference-information-${referenceIndex.display}")
+                  attributes = Map("id" -> "change-extra-reference-information")
                 )
               )
             )
@@ -2348,7 +2348,7 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                   content = msg"site.edit",
                   href = TIRCarnetReferenceController.onPageLoad(lrn, index, referenceIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"change-tir-carnet-reference-${referenceIndex.display}")
+                  attributes = Map("id" -> "change-tir-carnet-reference")
                 )
               )
             )
@@ -2391,7 +2391,7 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                   content = msg"site.edit",
                   href = DocumentTypeController.onPageLoad(lrn, index, referenceIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"change-document-type-${referenceIndex.display}")
+                  attributes = Map("id" -> "change-document-type")
                 )
               )
             )
@@ -2434,7 +2434,7 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                   content = msg"site.edit",
                   href = DocumentReferenceController.onPageLoad(lrn, index, referenceIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"change-document-reference-${referenceIndex.display}")
+                  attributes = Map("id" -> "change-document-reference")
                 )
               )
             )
@@ -2475,7 +2475,7 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                   content = msg"site.edit",
                   href = AddExtraDocumentInformationController.onPageLoad(lrn, index, referenceIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"change-add-extra-document-information-${referenceIndex.display}")
+                  attributes = Map("id" -> "change-add-extra-document-information")
                 )
               )
             )
@@ -2518,7 +2518,7 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                   content = msg"site.edit",
                   href = DocumentExtraInformationController.onPageLoad(lrn, index, referenceIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"change-extra-document-information-${referenceIndex.display}")
+                  attributes = Map("id" -> "change-extra-document-information")
                 )
               )
             )

--- a/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
+++ b/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
@@ -2146,43 +2146,87 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
 
     "referenceTypeRow" - {
 
-      val refType: String = "TYPE"
+      val code = "code"
 
       "return None" - {
+
         "ReferenceTypePage undefined at index" in {
 
           val answers = emptyUserAnswers
 
           val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
-          val result = helper.referenceTypeRow(index, referenceIndex)
+          val result = helper.referenceTypeRow(index, referenceIndex, PreviousReferencesDocumentTypeList(Nil))
+          result mustBe None
+        }
+
+        "reference type not found" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(ReferenceTypePage(index, referenceIndex))(code)
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.referenceTypeRow(index, referenceIndex, PreviousReferencesDocumentTypeList(Nil))
+
           result mustBe None
         }
       }
 
       "return Some(row)" - {
-        "ReferenceTypePage defined at index" in {
+        "ReferenceTypePage defined at index" - {
 
-          val answers = emptyUserAnswers.unsafeSetVal(ReferenceTypePage(index, referenceIndex))(refType)
+          "description defined" in {
 
-          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
-          val result = helper.referenceTypeRow(index, referenceIndex)
+            val description = "description"
+            val reference   = PreviousReferencesDocumentType(code, Some(description))
 
-          val label = msg"referenceType.checkYourAnswersLabel"
+            val answers = emptyUserAnswers.unsafeSetVal(ReferenceTypePage(index, referenceIndex))(code)
 
-          result mustBe Some(
-            Row(
-              key = Key(label, classes = Seq("govuk-!-width-one-half")),
-              value = Value(lit"$refType"),
-              actions = List(
-                Action(
-                  content = msg"site.edit",
-                  href = ReferenceTypeController.onPageLoad(lrn, index, referenceIndex, mode).url,
-                  visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> "change-reference-type")
+            val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+            val result = helper.referenceTypeRow(index, referenceIndex, PreviousReferencesDocumentTypeList(Seq(reference)))
+
+            val label = msg"referenceType.checkYourAnswersLabel"
+
+            result mustBe Some(
+              Row(
+                key = Key(label, classes = Seq("govuk-!-width-one-half")),
+                value = Value(lit"($code) $description"),
+                actions = List(
+                  Action(
+                    content = msg"site.edit",
+                    href = ReferenceTypeController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                    visuallyHiddenText = Some(label),
+                    attributes = Map("id" -> "change-reference-type")
+                  )
                 )
               )
             )
-          )
+          }
+
+          "description not defined" in {
+
+            val reference = PreviousReferencesDocumentType(code, None)
+
+            val answers = emptyUserAnswers.unsafeSetVal(ReferenceTypePage(index, referenceIndex))(code)
+
+            val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+            val result = helper.referenceTypeRow(index, referenceIndex, PreviousReferencesDocumentTypeList(Seq(reference)))
+
+            val label = msg"referenceType.checkYourAnswersLabel"
+
+            result mustBe Some(
+              Row(
+                key = Key(label, classes = Seq("govuk-!-width-one-half")),
+                value = Value(lit"(${reference.code}) "),
+                actions = List(
+                  Action(
+                    content = msg"site.edit",
+                    href = ReferenceTypeController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                    visuallyHiddenText = Some(label),
+                    attributes = Map("id" -> "change-reference-type")
+                  )
+                )
+              )
+            )
+          }
         }
       }
     }
@@ -2359,15 +2403,27 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
 
     "documentTypeRow" - {
 
-      val docType: String = "TYPE"
+      val documentCode: String   = "DOCUMENT CODE"
+      val document: DocumentType = DocumentType(documentCode, "DESCRIPTION", transportDocument = true)
 
       "return None" - {
+
         "DocumentTypePage undefined at index" in {
 
           val answers = emptyUserAnswers
 
           val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
-          val result = helper.documentTypeRow(index, referenceIndex)
+          val result = helper.documentTypeRow(index, referenceIndex, DocumentTypeList(Nil))
+          result mustBe None
+        }
+
+        "document type not found" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(DocumentTypePage(index, referenceIndex))(documentCode)
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.documentTypeRow(index, referenceIndex, DocumentTypeList(Nil))
+
           result mustBe None
         }
       }
@@ -2375,17 +2431,17 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
       "return Some(row)" - {
         "DocumentTypePage defined at index" in {
 
-          val answers = emptyUserAnswers.unsafeSetVal(DocumentTypePage(index, referenceIndex))(docType)
+          val answers = emptyUserAnswers.unsafeSetVal(DocumentTypePage(index, referenceIndex))(documentCode)
 
           val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
-          val result = helper.documentTypeRow(index, referenceIndex)
+          val result = helper.documentTypeRow(index, referenceIndex, DocumentTypeList(Seq(document)))
 
           val label = msg"documentType.checkYourAnswersLabel"
 
           result mustBe Some(
             Row(
               key = Key(label, classes = Seq("govuk-!-width-one-half")),
-              value = Value(lit"$docType"),
+              value = Value(lit"(${document.code}) ${document.description}"),
               actions = List(
                 Action(
                   content = msg"site.edit",

--- a/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
+++ b/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
@@ -182,9 +182,9 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
               actions = List(
                 Action(
                   content = msg"site.edit",
-                  href = controllers.addItems.documents.routes.TIRCarnetReferenceController.onPageLoad(lrn, index, documentIndex, mode).url,
+                  href = controllers.addItems.documents.routes.DocumentCheckYourAnswersController.onPageLoad(lrn, index, documentIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"change-document-${index.display}-${documentIndex.display}")
+                  attributes = Map("id" -> s"change-document-${documentIndex.display}")
                 )
               )
             )
@@ -209,15 +209,15 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
               actions = List(
                 Action(
                   content = msg"site.edit",
-                  href = controllers.addItems.documents.routes.DocumentTypeController.onPageLoad(lrn, index, documentIndex, mode).url,
+                  href = controllers.addItems.documents.routes.DocumentCheckYourAnswersController.onPageLoad(lrn, index, documentIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"change-document-${index.display}-${documentIndex.display}")
+                  attributes = Map("id" -> s"change-document-${documentIndex.display}")
                 ),
                 Action(
                   content = msg"site.delete",
                   href = controllers.addItems.documents.routes.ConfirmRemoveDocumentController.onPageLoad(lrn, index, documentIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"remove-document-${index.display}-${documentIndex.display}")
+                  attributes = Map("id" -> s"remove-document-${documentIndex.display}")
                 )
               )
             )
@@ -256,7 +256,6 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
 
       "return Some(row)" - {
 
-        // TODO - investigate if this test needs changing
         "Option4 declaration type and first index" in {
 
           val answers = emptyUserAnswers
@@ -266,18 +265,18 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
           val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
           val result = helper.documentSectionRow(index, referenceIndex, DocumentTypeList(Seq(document)))
 
-          val label = lit"(${document.code}) ${document.description}"
+          val label = msg"addDocuments.documentList.label".withArgs(documentIndex.display)
 
           result mustBe Some(
             Row(
-              key = Key(label),
-              value = Value(lit""),
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(lit"(${document.code}) ${document.description}"),
               actions = List(
                 Action(
                   content = msg"site.edit",
-                  href = controllers.addItems.documents.routes.TIRCarnetReferenceController.onPageLoad(lrn, index, documentIndex, mode).url,
+                  href = controllers.addItems.documents.routes.DocumentCheckYourAnswersController.onPageLoad(lrn, index, documentIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"change-document-${index.display}-${documentIndex.display}")
+                  attributes = Map("id" -> s"change-document-${documentIndex.display}")
                 )
               )
             )
@@ -1194,15 +1193,15 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                 actions = List(
                   Action(
                     content = msg"site.edit",
-                    href = ReferenceTypeController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                    href = ReferenceCheckYourAnswersController.onPageLoad(lrn, index, referenceIndex, mode).url,
                     visuallyHiddenText = Some(label),
-                    attributes = Map("id" -> s"change-reference-document-type-${index.display}-${referenceIndex.display}")
+                    attributes = Map("id" -> s"change-reference-document-${referenceIndex.display}")
                   ),
                   Action(
                     content = msg"site.delete",
                     href = ConfirmRemovePreviousAdministrativeReferenceController.onPageLoad(lrn, index, referenceIndex, mode).url,
                     visuallyHiddenText = Some(label),
-                    attributes = Map("id" -> s"remove-reference-document-type-${index.display}-${referenceIndex.display}")
+                    attributes = Map("id" -> s"remove-reference-document-${referenceIndex.display}")
                   )
                 )
               )
@@ -1229,15 +1228,15 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                 actions = List(
                   Action(
                     content = msg"site.edit",
-                    href = ReferenceTypeController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                    href = ReferenceCheckYourAnswersController.onPageLoad(lrn, index, referenceIndex, mode).url,
                     visuallyHiddenText = Some(label),
-                    attributes = Map("id" -> s"change-reference-document-type-${index.display}-${referenceIndex.display}")
+                    attributes = Map("id" -> s"change-reference-document-${referenceIndex.display}")
                   ),
                   Action(
                     content = msg"site.delete",
                     href = ConfirmRemovePreviousAdministrativeReferenceController.onPageLoad(lrn, index, referenceIndex, mode).url,
                     visuallyHiddenText = Some(label),
-                    attributes = Map("id" -> s"remove-reference-document-type-${index.display}-${referenceIndex.display}")
+                    attributes = Map("id" -> s"remove-reference-document-${referenceIndex.display}")
                   )
                 )
               )
@@ -1357,7 +1356,7 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
               actions = List(
                 Action(
                   content = msg"site.edit",
-                  href = PackageTypeController.onPageLoad(lrn, itemIndex, packageIndex, mode).url,
+                  href = PackageCheckYourAnswersController.onPageLoad(lrn, itemIndex, packageIndex, mode).url,
                   visuallyHiddenText = Some(label),
                   attributes = Map("id" -> s"change-package-${packageIndex.display}")
                 ),

--- a/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
+++ b/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
@@ -2144,5 +2144,388 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
       }
     }
 
+    "referenceTypeRow" - {
+
+      val refType: String = "TYPE"
+
+      "return None" - {
+        "ReferenceTypePage undefined at index" in {
+
+          val answers = emptyUserAnswers
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.referenceTypeRow(index, referenceIndex)
+          result mustBe None
+        }
+      }
+
+      "return Some(row)" - {
+        "ReferenceTypePage defined at index" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(ReferenceTypePage(index, referenceIndex))(refType)
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.referenceTypeRow(index, referenceIndex)
+
+          val label = msg"referenceType.checkYourAnswersLabel"
+
+          result mustBe Some(
+            Row(
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(lit"$refType"),
+              actions = List(
+                Action(
+                  content = msg"site.edit",
+                  href = ReferenceTypeController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> s"change-reference-type-${referenceIndex.display}")
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
+    "previousReferenceRow" - {
+
+      val reference: String = "REFERENCE"
+
+      "return None" - {
+        "PreviousReferencePage undefined at index" in {
+
+          val answers = emptyUserAnswers
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.previousReferenceRow(index, referenceIndex)
+          result mustBe None
+        }
+      }
+
+      "return Some(row)" - {
+        "PreviousReferencePage defined at index" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(PreviousReferencePage(index, referenceIndex))(reference)
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.previousReferenceRow(index, referenceIndex)
+
+          val label = msg"previousReference.checkYourAnswersLabel"
+
+          result mustBe Some(
+            Row(
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(lit"$reference"),
+              actions = List(
+                Action(
+                  content = msg"site.edit",
+                  href = PreviousReferenceController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> s"change-previous-reference-${referenceIndex.display}")
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
+    "addExtraReferenceInformationRow" - {
+
+      "return None" - {
+        "AddExtraInformationPage undefined at index" in {
+
+          val answers = emptyUserAnswers
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.addExtraReferenceInformationRow(index, referenceIndex)
+          result mustBe None
+        }
+      }
+
+      "return Some(row)" - {
+        "AddExtraInformationPage defined at index" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(AddExtraInformationPage(index, referenceIndex))(true)
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.addExtraReferenceInformationRow(index, referenceIndex)
+
+          val label = msg"addExtraInformation.checkYourAnswersLabel"
+
+          result mustBe Some(
+            Row(
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(msg"site.yes"),
+              actions = List(
+                Action(
+                  content = msg"site.edit",
+                  href = AddExtraInformationController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> s"change-add-extra-reference-information-${referenceIndex.display}")
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
+    "extraReferenceInformationRow" - {
+
+      val extraInfo: String = "INFO"
+
+      "return None" - {
+        "ExtraInformationPage undefined at index" in {
+
+          val answers = emptyUserAnswers
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.extraReferenceInformationRow(index, referenceIndex)
+          result mustBe None
+        }
+      }
+
+      "return Some(row)" - {
+        "ExtraInformationPage defined at index" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(ExtraInformationPage(index, referenceIndex))(extraInfo)
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.extraReferenceInformationRow(index, referenceIndex)
+
+          val label = msg"extraInformation.checkYourAnswersLabel"
+
+          result mustBe Some(
+            Row(
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(lit"$extraInfo"),
+              actions = List(
+                Action(
+                  content = msg"site.edit",
+                  href = ExtraInformationController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> s"change-extra-reference-information-${referenceIndex.display}")
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
+    "tirCarnetReferenceRow" - {
+
+      val reference: String = "REFERENCE"
+
+      "return None" - {
+        "TIRCarnetReferencePage undefined at index" in {
+
+          val answers = emptyUserAnswers
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.tirCarnetReferenceRow(index, referenceIndex)
+          result mustBe None
+        }
+      }
+
+      "return Some(row)" - {
+        "TIRCarnetReferencePage defined at index" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(TIRCarnetReferencePage(index, referenceIndex))(reference)
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.tirCarnetReferenceRow(index, referenceIndex)
+
+          val label = msg"tirCarnetReference.checkYourAnswersLabel"
+
+          result mustBe Some(
+            Row(
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(lit"$reference"),
+              actions = List(
+                Action(
+                  content = msg"site.edit",
+                  href = TIRCarnetReferenceController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> s"change-tir-carnet-reference-${referenceIndex.display}")
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
+    "documentTypeRow" - {
+
+      val docType: String = "TYPE"
+
+      "return None" - {
+        "DocumentTypePage undefined at index" in {
+
+          val answers = emptyUserAnswers
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.documentTypeRow(index, referenceIndex)
+          result mustBe None
+        }
+      }
+
+      "return Some(row)" - {
+        "DocumentTypePage defined at index" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(DocumentTypePage(index, referenceIndex))(docType)
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.documentTypeRow(index, referenceIndex)
+
+          val label = msg"documentType.checkYourAnswersLabel"
+
+          result mustBe Some(
+            Row(
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(lit"$docType"),
+              actions = List(
+                Action(
+                  content = msg"site.edit",
+                  href = DocumentTypeController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> s"change-document-type-${referenceIndex.display}")
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
+    "documentReferenceRow" - {
+
+      val reference: String = "REFERENCE"
+
+      "return None" - {
+        "DocumentReferencePage undefined at index" in {
+
+          val answers = emptyUserAnswers
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.documentReferenceRow(index, referenceIndex)
+          result mustBe None
+        }
+      }
+
+      "return Some(row)" - {
+        "DocumentReferencePage defined at index" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(DocumentReferencePage(index, referenceIndex))(reference)
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.documentReferenceRow(index, referenceIndex)
+
+          val label = msg"documentReference.checkYourAnswersLabel"
+
+          result mustBe Some(
+            Row(
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(lit"$reference"),
+              actions = List(
+                Action(
+                  content = msg"site.edit",
+                  href = DocumentReferenceController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> s"change-document-reference-${referenceIndex.display}")
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
+    "addExtraDocumentInformationRow" - {
+
+      "return None" - {
+        "AddExtraDocumentInformationPage undefined at index" in {
+
+          val answers = emptyUserAnswers
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.addExtraDocumentInformationRow(index, referenceIndex)
+          result mustBe None
+        }
+      }
+
+      "return Some(row)" - {
+        "AddExtraDocumentInformationPage defined at index" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(AddExtraDocumentInformationPage(index, referenceIndex))(true)
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.addExtraDocumentInformationRow(index, referenceIndex)
+
+          val label = msg"addExtraDocumentInformation.checkYourAnswersLabel"
+
+          result mustBe Some(
+            Row(
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(msg"site.yes"),
+              actions = List(
+                Action(
+                  content = msg"site.edit",
+                  href = AddExtraDocumentInformationController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> s"change-add-extra-document-information-${referenceIndex.display}")
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
+    "extraDocumentInformationRow" - {
+
+      val information: String = "INFORMATION"
+
+      "return None" - {
+        "DocumentExtraInformationPage undefined at index" in {
+
+          val answers = emptyUserAnswers
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.extraDocumentInformationRow(index, referenceIndex)
+          result mustBe None
+        }
+      }
+
+      "return Some(row)" - {
+        "DocumentExtraInformationPage defined at index" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(DocumentExtraInformationPage(index, referenceIndex))(information)
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.extraDocumentInformationRow(index, referenceIndex)
+
+          val label = msg"documentExtraInformation.checkYourAnswersLabel"
+
+          result mustBe Some(
+            Row(
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(lit"$information"),
+              actions = List(
+                Action(
+                  content = msg"site.edit",
+                  href = DocumentExtraInformationController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> s"change-extra-document-information-${referenceIndex.display}")
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
   }
 }

--- a/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
+++ b/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
@@ -1407,7 +1407,7 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                   content = msg"site.edit",
                   href = PackageTypeController.onPageLoad(lrn, itemIndex, packageIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"change-package-${packageIndex.display}")
+                  attributes = Map("id" -> s"change-package-type")
                 )
               )
             )
@@ -1449,7 +1449,8 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                 Action(
                   content = msg"site.edit",
                   href = HowManyPackagesController.onPageLoad(lrn, itemIndex, packageIndex, mode).url,
-                  visuallyHiddenText = Some(label)
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> s"change-number-of-packages")
                 )
               )
             )
@@ -1491,7 +1492,92 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                 Action(
                   content = msg"site.edit",
                   href = TotalPiecesController.onPageLoad(lrn, itemIndex, packageIndex, mode).url,
-                  visuallyHiddenText = Some(label)
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> s"change-total-pieces")
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
+    "addMark" - {
+
+      "return None" - {
+        "AddMarkPage undefined at index" in {
+
+          val answers = emptyUserAnswers
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.addMark(itemIndex, packageIndex)
+          result mustBe None
+        }
+      }
+
+      "return Some(row)" - {
+        "AddMarkPage defined at index" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(AddMarkPage(itemIndex, packageIndex))(true)
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.addMark(itemIndex, packageIndex)
+
+          val label = msg"addMark.checkYourAnswersLabel"
+
+          result mustBe Some(
+            Row(
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(msg"site.yes"),
+              actions = List(
+                Action(
+                  content = msg"site.edit",
+                  href = AddMarkController.onPageLoad(lrn, itemIndex, packageIndex, mode).url,
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> "change-add-mark")
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
+    "mark" - {
+
+      val markOrNumber: String = "mark"
+
+      "return None" - {
+        "DeclareMarkPage undefined at index" in {
+
+          val answers = emptyUserAnswers
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.mark(itemIndex, packageIndex)
+          result mustBe None
+        }
+      }
+
+      "return Some(row)" - {
+        "DeclareMarkPage defined at index" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(DeclareMarkPage(itemIndex, packageIndex))(markOrNumber)
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.mark(itemIndex, packageIndex)
+
+          val label = msg"declareMark.checkYourAnswersLabel"
+
+          result mustBe Some(
+            Row(
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(lit"$markOrNumber"),
+              actions = List(
+                Action(
+                  content = msg"site.edit",
+                  href = DeclareMarkController.onPageLoad(lrn, itemIndex, packageIndex, mode).url,
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> "change-mark")
                 )
               )
             )

--- a/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
+++ b/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
@@ -1373,6 +1373,51 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
       }
     }
 
+    "packageSectionRow" - {
+
+      val description: String      = "DESCRIPTION"
+      val code: String             = "CODE"
+      val packageType: PackageType = PackageType(code, description)
+
+      "return None" - {
+        "PackageTypePage undefined at index" in {
+
+          val answers = emptyUserAnswers
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.packageSectionRow(itemIndex, packageIndex)
+          result mustBe None
+        }
+      }
+
+      "return Some(row)" - {
+        "PackageTypePage defined at index" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(PackageTypePage(itemIndex, packageIndex))(packageType)
+
+          val helper = new AddItemsCheckYourAnswersHelper(answers, mode)
+          val result = helper.packageSectionRow(itemIndex, packageIndex)
+
+          val label = msg"addAnotherPackage.packageList.label".withArgs(packageIndex.display)
+
+          result mustBe Some(
+            Row(
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(lit"$description ($code)"),
+              actions = List(
+                Action(
+                  content = msg"site.edit",
+                  href = PackageTypeController.onPageLoad(lrn, itemIndex, packageIndex, mode).url,
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> s"change-package-${packageIndex.display}")
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
     "packageType" - {
 
       val packageType: PackageType = PackageType("CODE", "DESCRIPTION")

--- a/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
+++ b/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
@@ -256,6 +256,7 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
 
       "return Some(row)" - {
 
+        // TODO - investigate if this test needs changing
         "Option4 declaration type and first index" in {
 
           val answers = emptyUserAnswers
@@ -301,9 +302,9 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
               actions = List(
                 Action(
                   content = msg"site.edit",
-                  href = controllers.addItems.documents.routes.DocumentTypeController.onPageLoad(lrn, itemIndex, documentIndex, mode).url,
+                  href = controllers.addItems.documents.routes.DocumentCheckYourAnswersController.onPageLoad(lrn, itemIndex, documentIndex, mode).url,
                   visuallyHiddenText = Some(label),
-                  attributes = Map("id" -> s"change-document-${index.display}-${documentIndex.display}")
+                  attributes = Map("id" -> s"change-document-${documentIndex.display}")
                 )
               )
             )
@@ -1102,9 +1103,9 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                 actions = List(
                   Action(
                     content = msg"site.edit",
-                    href = ReferenceTypeController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                    href = ReferenceCheckYourAnswersController.onPageLoad(lrn, index, referenceIndex, mode).url,
                     visuallyHiddenText = Some(label),
-                    attributes = Map("id" -> s"change-item-${index.display}-${referenceIndex.display}")
+                    attributes = Map("id" -> s"change-reference-${referenceIndex.display}")
                   )
                 )
               )
@@ -1131,9 +1132,9 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
                 actions = List(
                   Action(
                     content = msg"site.edit",
-                    href = ReferenceTypeController.onPageLoad(lrn, index, referenceIndex, mode).url,
+                    href = ReferenceCheckYourAnswersController.onPageLoad(lrn, index, referenceIndex, mode).url,
                     visuallyHiddenText = Some(label),
-                    attributes = Map("id" -> s"change-item-${index.display}-${referenceIndex.display}")
+                    attributes = Map("id" -> s"change-reference-${referenceIndex.display}")
                   )
                 )
               )

--- a/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
+++ b/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
@@ -2256,7 +2256,7 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
           result mustBe Some(
             Row(
               key = Key(label, classes = Seq("govuk-!-width-one-half")),
-              value = Value(msg"site.ye"),
+              value = Value(msg"site.yes"),
               actions = List(
                 Action(
                   content = msg"site.edit",

--- a/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
+++ b/test/utils/AddItemsCheckYourAnswersHelperSpec.scala
@@ -1407,7 +1407,7 @@ class AddItemsCheckYourAnswersHelperSpec extends SpecBase with UserAnswersSpecHe
               actions = List(
                 Action(
                   content = msg"site.edit",
-                  href = PackageTypeController.onPageLoad(lrn, itemIndex, packageIndex, mode).url,
+                  href = PackagesCheckYourAnswersController.onPageLoad(lrn, itemIndex, packageIndex, mode).url,
                   visuallyHiddenText = Some(label),
                   attributes = Map("id" -> s"change-package-${packageIndex.display}")
                 )

--- a/test/utils/SpecialMentionsCheckYourAnswersHelperSpec.scala
+++ b/test/utils/SpecialMentionsCheckYourAnswersHelperSpec.scala
@@ -17,10 +17,13 @@
 package utils
 
 import base.{GeneratorSpec, SpecBase}
+import controllers.addItems.specialMentions.routes
 import generators.ReferenceDataGenerators
 import models.reference.SpecialMention
+import models.userAnswerScenarios.Scenario1.UserAnswersSpecHelperOps
 import models.{CheckMode, Mode, SpecialMentionList, UserAnswers}
-import pages.addItems.specialMentions.{AddSpecialMentionPage, SpecialMentionTypePage}
+import pages.addItems.specialMentions.{AddSpecialMentionPage, SpecialMentionAdditionalInfoPage, SpecialMentionTypePage}
+import uk.gov.hmrc.viewmodels.SummaryList.{Action, Key, Row, Value}
 import uk.gov.hmrc.viewmodels.Text.{Literal, Message}
 import uk.gov.hmrc.viewmodels._
 import viewModels.AddAnotherViewModel
@@ -132,7 +135,7 @@ class SpecialMentionsCheckYourAnswersHelperSpec extends SpecBase with GeneratorS
 
         cya.addAnother(index, msg"addItems.checkYourAnswersLabel.specialMentions") mustBe
           AddAnotherViewModel(
-            controllers.addItems.specialMentions.routes.AddAnotherSpecialMentionController.onPageLoad(lrn, itemIndex, mode).url,
+            routes.AddAnotherSpecialMentionController.onPageLoad(lrn, itemIndex, mode).url,
             msg"addItems.checkYourAnswersLabel.specialMentions"
           )
 
@@ -146,7 +149,7 @@ class SpecialMentionsCheckYourAnswersHelperSpec extends SpecBase with GeneratorS
 
         cya.addAnother(index, msg"addItems.checkYourAnswersLabel.specialMentions") mustBe
           AddAnotherViewModel(
-            controllers.addItems.specialMentions.routes.AddSpecialMentionController.onPageLoad(lrn, itemIndex, mode).url,
+            routes.AddSpecialMentionController.onPageLoad(lrn, itemIndex, mode).url,
             msg"addItems.checkYourAnswersLabel.specialMentions"
           )
 
@@ -158,12 +161,96 @@ class SpecialMentionsCheckYourAnswersHelperSpec extends SpecBase with GeneratorS
 
         cya.addAnother(index, msg"addItems.checkYourAnswersLabel.specialMentions") mustBe
           AddAnotherViewModel(
-            controllers.addItems.specialMentions.routes.AddSpecialMentionController.onPageLoad(lrn, itemIndex, mode).url,
+            routes.AddSpecialMentionController.onPageLoad(lrn, itemIndex, mode).url,
             msg"addItems.checkYourAnswersLabel.specialMentions"
           )
 
       }
 
+    }
+
+    "specialMentionTypeRow" - {
+
+      val specialMentionTyne: String = "TYPE"
+
+      "return None" - {
+        "SpecialMentionTypePage undefined at itemIndex" in {
+
+          val answers = emptyUserAnswers
+
+          val helper = new SpecialMentionsCheckYourAnswersHelper(answers, mode)
+          val result = helper.specialMentionTypeRow(itemIndex, referenceIndex)
+          result mustBe None
+        }
+      }
+
+      "return Some(row)" - {
+        "SpecialMentionTypePage defined at itemIndex" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(SpecialMentionTypePage(itemIndex, referenceIndex))(specialMentionTyne)
+
+          val helper = new SpecialMentionsCheckYourAnswersHelper(answers, mode)
+          val result = helper.specialMentionTypeRow(itemIndex, referenceIndex)
+
+          val label = msg"specialMentionType.checkYourAnswersLabel"
+
+          result mustBe Some(
+            Row(
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(lit"$specialMentionTyne"),
+              actions = List(
+                Action(
+                  content = msg"site.edit",
+                  href = routes.SpecialMentionTypeController.onPageLoad(lrn, itemIndex, referenceIndex, mode).url,
+                  visuallyHiddenText = Some(label)
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
+    "specialMentionAdditionalInfoRow" - {
+
+      val additionalInformation: String = "INFO"
+
+      "return None" - {
+        "SpecialMentionAdditionalInfoPage undefined at itemIndex" in {
+
+          val answers = emptyUserAnswers
+
+          val helper = new SpecialMentionsCheckYourAnswersHelper(answers, mode)
+          val result = helper.specialMentionAdditionalInfoRow(itemIndex, referenceIndex)
+          result mustBe None
+        }
+      }
+
+      "return Some(row)" - {
+        "SpecialMentionAdditionalInfoPage defined at itemIndex" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(SpecialMentionAdditionalInfoPage(itemIndex, referenceIndex))(additionalInformation)
+
+          val helper = new SpecialMentionsCheckYourAnswersHelper(answers, mode)
+          val result = helper.specialMentionAdditionalInfoRow(itemIndex, referenceIndex)
+
+          val label = msg"specialMentionAdditionalInfo.checkYourAnswersLabel"
+
+          result mustBe Some(
+            Row(
+              key = Key(label, classes = Seq("govuk-!-width-one-half")),
+              value = Value(lit"$additionalInformation"),
+              actions = List(
+                Action(
+                  content = msg"site.edit",
+                  href = routes.SpecialMentionAdditionalInfoController.onPageLoad(lrn, itemIndex, referenceIndex, mode).url,
+                  visuallyHiddenText = Some(label)
+                )
+              )
+            )
+          )
+        }
+      }
     }
 
   }

--- a/test/utils/SpecialMentionsCheckYourAnswersHelperSpec.scala
+++ b/test/utils/SpecialMentionsCheckYourAnswersHelperSpec.scala
@@ -171,15 +171,27 @@ class SpecialMentionsCheckYourAnswersHelperSpec extends SpecBase with GeneratorS
 
     "specialMentionTypeRow" - {
 
-      val specialMentionTyne: String = "TYPE"
+      val code           = "code"
+      val specialMention = SpecialMention(code, "description")
 
       "return None" - {
+
         "SpecialMentionTypePage undefined at itemIndex" in {
 
           val answers = emptyUserAnswers
 
           val helper = new SpecialMentionsCheckYourAnswersHelper(answers, mode)
-          val result = helper.specialMentionTypeRow(itemIndex, referenceIndex)
+          val result = helper.specialMentionTypeRow(itemIndex, referenceIndex, SpecialMentionList(Nil))
+          result mustBe None
+        }
+
+        "special mention type not found" in {
+
+          val answers = emptyUserAnswers.unsafeSetVal(SpecialMentionTypePage(index, referenceIndex))(code)
+
+          val helper = new SpecialMentionsCheckYourAnswersHelper(answers, mode)
+          val result = helper.specialMentionTypeRow(index, referenceIndex, SpecialMentionList(Nil))
+
           result mustBe None
         }
       }
@@ -187,17 +199,17 @@ class SpecialMentionsCheckYourAnswersHelperSpec extends SpecBase with GeneratorS
       "return Some(row)" - {
         "SpecialMentionTypePage defined at itemIndex" in {
 
-          val answers = emptyUserAnswers.unsafeSetVal(SpecialMentionTypePage(itemIndex, referenceIndex))(specialMentionTyne)
+          val answers = emptyUserAnswers.unsafeSetVal(SpecialMentionTypePage(itemIndex, referenceIndex))(code)
 
           val helper = new SpecialMentionsCheckYourAnswersHelper(answers, mode)
-          val result = helper.specialMentionTypeRow(itemIndex, referenceIndex)
+          val result = helper.specialMentionTypeRow(itemIndex, referenceIndex, SpecialMentionList(Seq(specialMention)))
 
           val label = msg"specialMentionType.checkYourAnswersLabel"
 
           result mustBe Some(
             Row(
               key = Key(label, classes = Seq("govuk-!-width-one-half")),
-              value = Value(lit"$specialMentionTyne"),
+              value = Value(lit"($code) ${specialMention.description}"),
               actions = List(
                 Action(
                   content = msg"site.edit",

--- a/test/utils/SpecialMentionsCheckYourAnswersHelperSpec.scala
+++ b/test/utils/SpecialMentionsCheckYourAnswersHelperSpec.scala
@@ -202,7 +202,8 @@ class SpecialMentionsCheckYourAnswersHelperSpec extends SpecBase with GeneratorS
                 Action(
                   content = msg"site.edit",
                   href = routes.SpecialMentionTypeController.onPageLoad(lrn, itemIndex, referenceIndex, mode).url,
-                  visuallyHiddenText = Some(label)
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> "change-special-mention-type")
                 )
               )
             )
@@ -244,7 +245,8 @@ class SpecialMentionsCheckYourAnswersHelperSpec extends SpecBase with GeneratorS
                 Action(
                   content = msg"site.edit",
                   href = routes.SpecialMentionAdditionalInfoController.onPageLoad(lrn, itemIndex, referenceIndex, mode).url,
-                  visuallyHiddenText = Some(label)
+                  visuallyHiddenText = Some(label),
+                  attributes = Map("id" -> "change-special-mention-additional-information")
                 )
               )
             )

--- a/test/viewModels/AddItemsCheckYourAnswersViewModelSpec.scala
+++ b/test/viewModels/AddItemsCheckYourAnswersViewModelSpec.scala
@@ -18,7 +18,7 @@ package viewModels
 
 import base.SpecBase
 import models.reference._
-import models.{DocumentTypeList, Index, PreviousReferencesDocumentTypeList, SpecialMentionList, UserAnswers}
+import models.{DocumentTypeList, PreviousReferencesDocumentTypeList, SpecialMentionList, UserAnswers}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import pages._
@@ -91,37 +91,12 @@ class AddItemsCheckYourAnswersViewModelSpec extends SpecBase with ScalaCheckProp
 
     "packages section have title and contain all rows when package type is not unpacked" in {
       data.sections(3).sectionTitle.get mustBe msg"addItems.checkYourAnswersLabel.packages"
-      data.sections(3).rows.length mustEqual 2
+      data.sections(3).rows.length mustEqual 1
     }
 
     "packages section have title and contain all rows when package type is unpacked" in {
       dataWithUnpackedPackages.sections(3).sectionTitle.get mustBe msg"addItems.checkYourAnswersLabel.packages"
-      dataWithUnpackedPackages.sections(3).rows.length mustEqual 2
-    }
-
-    "packages sections must have section for each package" in {
-      val answers = (0 to 2).foldLeft(emptyUserAnswers)((acc, i) => {
-        acc
-          .set(PackageTypePage(index, Index(i)), PackageType("AB", "Description") ).success.value
-          .set(HowManyPackagesPage(index, Index(i)), 1).success.value
-      })
-
-      val result = viewModel(answers)
-
-      result.sections(3).sectionTitle.get mustBe msg"addItems.checkYourAnswersLabel.packages"
-      result.sections(3).sectionSubTitle.get mustBe msg"addAnotherPackage.packageList.label".withArgs(1)
-      result.sections(3).rows.length mustEqual 2
-      result.sections(3).addAnother mustNot be(defined)
-
-      result.sections(4).sectionTitle mustNot be(defined)
-      result.sections(4).sectionSubTitle.get mustBe msg"addAnotherPackage.packageList.label".withArgs(2)
-      result.sections(4).rows.length mustEqual 2
-      result.sections(4).addAnother mustNot be(defined)
-
-      result.sections(5).sectionTitle mustNot be(defined)
-      result.sections(5).sectionSubTitle.get mustBe msg"addAnotherPackage.packageList.label".withArgs(3)
-      result.sections(5).rows.length mustEqual 2
-      result.sections(5).addAnother.get.content mustBe msg"addItems.checkYourAnswersLabel.packages.addRemove"
+      dataWithUnpackedPackages.sections(3).rows.length mustEqual 1
     }
   }
 

--- a/test/viewModels/DocumentsCheckYourAnswersViewModelSpec.scala
+++ b/test/viewModels/DocumentsCheckYourAnswersViewModelSpec.scala
@@ -17,7 +17,8 @@
 package viewModels
 
 import base.SpecBase
-import models.{NormalMode, UserAnswers}
+import models.reference.DocumentType
+import models.{DocumentTypeList, NormalMode, UserAnswers}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import pages.addItems._
 
@@ -25,8 +26,11 @@ class DocumentsCheckYourAnswersViewModelSpec extends SpecBase with ScalaCheckPro
 
   // format: off
 
+  private val code = "code"
+  private val document: DocumentType = DocumentType(code, "description", transportDocument = true)
+
   private def viewModel(userAnswers: UserAnswers): DocumentsCheckYourAnswersViewModel =
-    DocumentsCheckYourAnswersViewModel(userAnswers, itemIndex, packageIndex, NormalMode)
+    DocumentsCheckYourAnswersViewModel(userAnswers, itemIndex, packageIndex, NormalMode, DocumentTypeList(Seq(document)))
 
   "DocumentsCheckYourAnswersViewModel" - {
 
@@ -35,6 +39,7 @@ class DocumentsCheckYourAnswersViewModelSpec extends SpecBase with ScalaCheckPro
       "when TIR carnet reference" in {
         val userAnswers = emptyUserAnswers
           .set(TIRCarnetReferencePage(itemIndex, documentIndex), "ref").success.value
+          .set(DocumentTypePage(itemIndex, documentIndex), code).success.value
           .set(DocumentExtraInformationPage(itemIndex, documentIndex), "info").success.value
 
         val result = viewModel(userAnswers)
@@ -43,7 +48,7 @@ class DocumentsCheckYourAnswersViewModelSpec extends SpecBase with ScalaCheckPro
 
       "when not TIR carnet reference" in {
         val userAnswers = emptyUserAnswers
-          .set(DocumentTypePage(itemIndex, documentIndex), "type").success.value
+          .set(DocumentTypePage(itemIndex, documentIndex), code).success.value
           .set(DocumentReferencePage(itemIndex, documentIndex), "ref").success.value
           .set(AddExtraDocumentInformationPage(itemIndex, documentIndex), true).success.value
           .set(DocumentExtraInformationPage(itemIndex, documentIndex), "info").success.value

--- a/test/viewModels/DocumentsCheckYourAnswersViewModelSpec.scala
+++ b/test/viewModels/DocumentsCheckYourAnswersViewModelSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewModels
+
+import base.SpecBase
+import models.{NormalMode, UserAnswers}
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import pages.addItems._
+
+class DocumentsCheckYourAnswersViewModelSpec extends SpecBase with ScalaCheckPropertyChecks {
+
+  // format: off
+
+  private def viewModel(userAnswers: UserAnswers): DocumentsCheckYourAnswersViewModel =
+    DocumentsCheckYourAnswersViewModel(userAnswers, itemIndex, packageIndex, NormalMode)
+
+  "DocumentsCheckYourAnswersViewModel" - {
+
+    "display the correct number of rows" - {
+
+      "when TIR carnet reference" in {
+        val userAnswers = emptyUserAnswers
+          .set(TIRCarnetReferencePage(itemIndex, documentIndex), "ref").success.value
+          .set(DocumentExtraInformationPage(itemIndex, documentIndex), "info").success.value
+
+        val result = viewModel(userAnswers)
+        result.section.rows.length mustEqual 2
+      }
+
+      "when not TIR carnet reference" in {
+        val userAnswers = emptyUserAnswers
+          .set(DocumentTypePage(itemIndex, documentIndex), "type").success.value
+          .set(DocumentReferencePage(itemIndex, documentIndex), "ref").success.value
+          .set(AddExtraDocumentInformationPage(itemIndex, documentIndex), true).success.value
+          .set(DocumentExtraInformationPage(itemIndex, documentIndex), "info").success.value
+
+        val result = viewModel(userAnswers)
+        result.section.rows.length mustEqual 4
+      }
+    }
+  }
+
+  // format: on
+}

--- a/test/viewModels/PackagesCheckYourAnswersViewModelSpec.scala
+++ b/test/viewModels/PackagesCheckYourAnswersViewModelSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewModels
+
+import base.SpecBase
+import models.reference._
+import models.{NormalMode, UserAnswers}
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import pages._
+import pages.addItems._
+
+class PackagesCheckYourAnswersViewModelSpec extends SpecBase with ScalaCheckPropertyChecks {
+
+  // format: off
+  // scalastyle:off magic.number
+
+  private def viewModel(userAnswers: UserAnswers): PackagesCheckYourAnswersViewModel =
+    PackagesCheckYourAnswersViewModel(userAnswers, itemIndex, packageIndex, NormalMode)
+
+  "PackagesCheckYourAnswersViewModel" - {
+
+    "display the correct number of rows" - {
+
+      "when how many packages" in {
+        val userAnswers = emptyUserAnswers
+          .set(PackageTypePage(index, itemIndex), PackageType("AB", "Description") ).success.value
+          .set(HowManyPackagesPage(index, itemIndex), 123).success.value
+          .set(DeclareMarkPage(index, itemIndex), "mark").success.value
+
+        val result = viewModel(userAnswers)
+        result.section.rows.length mustEqual 3
+      }
+
+      "when total pieces" in {
+        val userAnswers = emptyUserAnswers
+          .set(PackageTypePage(index, itemIndex), PackageType("AB", "Description") ).success.value
+          .set(TotalPiecesPage(index, itemIndex), 123).success.value
+          .set(AddMarkPage(index, itemIndex), true).success.value
+          .set(DeclareMarkPage(index, itemIndex), "mark").success.value
+
+        val result = viewModel(userAnswers)
+        result.section.rows.length mustEqual 4
+      }
+    }
+  }
+
+  // format: on
+  // scalastyle:on magic.number
+}

--- a/test/viewModels/PackagesCheckYourAnswersViewModelSpec.scala
+++ b/test/viewModels/PackagesCheckYourAnswersViewModelSpec.scala
@@ -37,9 +37,9 @@ class PackagesCheckYourAnswersViewModelSpec extends SpecBase with ScalaCheckProp
 
       "when how many packages" in {
         val userAnswers = emptyUserAnswers
-          .set(PackageTypePage(index, itemIndex), PackageType("AB", "Description") ).success.value
-          .set(HowManyPackagesPage(index, itemIndex), 123).success.value
-          .set(DeclareMarkPage(index, itemIndex), "mark").success.value
+          .set(PackageTypePage(itemIndex, packageIndex), PackageType("AB", "Description")).success.value
+          .set(HowManyPackagesPage(itemIndex, packageIndex), 123).success.value
+          .set(DeclareMarkPage(itemIndex, packageIndex), "mark").success.value
 
         val result = viewModel(userAnswers)
         result.section.rows.length mustEqual 3
@@ -47,10 +47,10 @@ class PackagesCheckYourAnswersViewModelSpec extends SpecBase with ScalaCheckProp
 
       "when total pieces" in {
         val userAnswers = emptyUserAnswers
-          .set(PackageTypePage(index, itemIndex), PackageType("AB", "Description") ).success.value
-          .set(TotalPiecesPage(index, itemIndex), 123).success.value
-          .set(AddMarkPage(index, itemIndex), true).success.value
-          .set(DeclareMarkPage(index, itemIndex), "mark").success.value
+          .set(PackageTypePage(itemIndex, packageIndex), PackageType("AB", "Description")).success.value
+          .set(TotalPiecesPage(itemIndex, packageIndex), 123).success.value
+          .set(AddMarkPage(itemIndex, packageIndex), true).success.value
+          .set(DeclareMarkPage(itemIndex, packageIndex), "mark").success.value
 
         val result = viewModel(userAnswers)
         result.section.rows.length mustEqual 4

--- a/test/viewModels/ReferencesCheckYourAnswersViewModelSpec.scala
+++ b/test/viewModels/ReferencesCheckYourAnswersViewModelSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewModels
+
+import base.SpecBase
+import models.{NormalMode, UserAnswers}
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import pages.addItems._
+
+class ReferencesCheckYourAnswersViewModelSpec extends SpecBase with ScalaCheckPropertyChecks {
+
+  // format: off
+
+  private def viewModel(userAnswers: UserAnswers): ReferencesCheckYourAnswersViewModel =
+    ReferencesCheckYourAnswersViewModel(userAnswers, itemIndex, packageIndex, NormalMode)
+
+  "ReferencesCheckYourAnswersViewModel" - {
+
+    "display the correct number of rows" in {
+
+      val userAnswers = emptyUserAnswers
+        .set(ReferenceTypePage(itemIndex, documentIndex), "type").success.value
+        .set(PreviousReferencePage(itemIndex, documentIndex), "ref").success.value
+        .set(AddExtraInformationPage(itemIndex, documentIndex), true).success.value
+        .set(ExtraInformationPage(itemIndex, documentIndex), "info").success.value
+
+      val result = viewModel(userAnswers)
+      result.section.rows.length mustEqual 4
+    }
+  }
+
+  // format: on
+}

--- a/test/viewModels/ReferencesCheckYourAnswersViewModelSpec.scala
+++ b/test/viewModels/ReferencesCheckYourAnswersViewModelSpec.scala
@@ -17,7 +17,8 @@
 package viewModels
 
 import base.SpecBase
-import models.{NormalMode, UserAnswers}
+import models.reference.PreviousReferencesDocumentType
+import models.{NormalMode, PreviousReferencesDocumentTypeList, UserAnswers}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import pages.addItems._
 
@@ -25,15 +26,18 @@ class ReferencesCheckYourAnswersViewModelSpec extends SpecBase with ScalaCheckPr
 
   // format: off
 
+  private val code = "code"
+  private val reference = PreviousReferencesDocumentType(code, None)
+
   private def viewModel(userAnswers: UserAnswers): ReferencesCheckYourAnswersViewModel =
-    ReferencesCheckYourAnswersViewModel(userAnswers, itemIndex, packageIndex, NormalMode)
+    ReferencesCheckYourAnswersViewModel(userAnswers, itemIndex, packageIndex, NormalMode, PreviousReferencesDocumentTypeList(Seq(reference)))
 
   "ReferencesCheckYourAnswersViewModel" - {
 
     "display the correct number of rows" in {
 
       val userAnswers = emptyUserAnswers
-        .set(ReferenceTypePage(itemIndex, documentIndex), "type").success.value
+        .set(ReferenceTypePage(itemIndex, documentIndex), code).success.value
         .set(PreviousReferencePage(itemIndex, documentIndex), "ref").success.value
         .set(AddExtraInformationPage(itemIndex, documentIndex), true).success.value
         .set(ExtraInformationPage(itemIndex, documentIndex), "info").success.value

--- a/test/viewModels/SpecialMentionsCheckYourAnswersViewModelSpec.scala
+++ b/test/viewModels/SpecialMentionsCheckYourAnswersViewModelSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewModels
+
+import base.SpecBase
+import models.{NormalMode, UserAnswers}
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import pages.addItems.specialMentions.{SpecialMentionAdditionalInfoPage, SpecialMentionTypePage}
+
+class SpecialMentionsCheckYourAnswersViewModelSpec extends SpecBase with ScalaCheckPropertyChecks {
+
+  // format: off
+
+  private def viewModel(userAnswers: UserAnswers): SpecialMentionsCheckYourAnswersViewModel =
+    SpecialMentionsCheckYourAnswersViewModel(userAnswers, itemIndex, referenceIndex, NormalMode)
+
+  "SpecialMentionsCheckYourAnswersViewModel" - {
+
+    "display the correct number of rows" in {
+
+      val userAnswers = emptyUserAnswers
+        .set(SpecialMentionTypePage(itemIndex, referenceIndex), "type").success.value
+        .set(SpecialMentionAdditionalInfoPage(itemIndex, referenceIndex), "info").success.value
+
+      val result = viewModel(userAnswers)
+      result.section.rows.length mustEqual 2
+    }
+  }
+
+  // format: on
+}

--- a/test/viewModels/SpecialMentionsCheckYourAnswersViewModelSpec.scala
+++ b/test/viewModels/SpecialMentionsCheckYourAnswersViewModelSpec.scala
@@ -17,7 +17,8 @@
 package viewModels
 
 import base.SpecBase
-import models.{NormalMode, UserAnswers}
+import models.reference.SpecialMention
+import models.{NormalMode, SpecialMentionList, UserAnswers}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import pages.addItems.specialMentions.{SpecialMentionAdditionalInfoPage, SpecialMentionTypePage}
 
@@ -25,15 +26,18 @@ class SpecialMentionsCheckYourAnswersViewModelSpec extends SpecBase with ScalaCh
 
   // format: off
 
+  private val code = "code"
+  private val specialMention = SpecialMention(code, "description")
+
   private def viewModel(userAnswers: UserAnswers): SpecialMentionsCheckYourAnswersViewModel =
-    SpecialMentionsCheckYourAnswersViewModel(userAnswers, itemIndex, referenceIndex, NormalMode)
+    SpecialMentionsCheckYourAnswersViewModel(userAnswers, itemIndex, referenceIndex, NormalMode, SpecialMentionList(Seq(specialMention)))
 
   "SpecialMentionsCheckYourAnswersViewModel" - {
 
     "display the correct number of rows" in {
 
       val userAnswers = emptyUserAnswers
-        .set(SpecialMentionTypePage(itemIndex, referenceIndex), "type").success.value
+        .set(SpecialMentionTypePage(itemIndex, referenceIndex), code).success.value
         .set(SpecialMentionAdditionalInfoPage(itemIndex, referenceIndex), "info").success.value
 
       val result = viewModel(userAnswers)


### PR DESCRIPTION
- When adding a package, the user now sees a check your answers page after answering the questions
- Items CYA now follows the same pattern for packages as it does for containers, documents etc.
- The change links then redirect to the check your answers page for the relevant package

The same has been done for documents, admin references and special mentions (but not containers as the journey is only one question)